### PR TITLE
Darwin updates

### DIFF
--- a/builders/scripts/builder_darwin_amd64_runtime
+++ b/builders/scripts/builder_darwin_amd64_runtime
@@ -1,4 +1,6 @@
 #!/bin/bash
+ln -s "/root/osxcross/target/bin/i386-apple-darwin15-install_name_tool" "/root/osxcross/target/bin/install_name_tool"
+ln -s "/root/osxcross/target/bin/i386-apple-darwin15-otool" "/root/osxcross/target/bin/otool"
 
 mkdir -p /root/runtime/lib
 cd "/root/runtime/lib/"
@@ -7,11 +9,124 @@ cd "/root/runtime/lib/"
 cp -d /root/osxcross/target/macports/pkgs/opt/local/lib/*.dylib "/root/runtime/lib"
 rm /root/runtime/lib/libpython2.7.dylib
 
+## Remove all the XQuartz files, not needed and shrink file size!
+cd "/root/runtime/lib"
+rm libGL.1.dylib
+rm libGL.dylib
+rm libGLESv1_CM.1.dylib
+rm libGLESv1_CM.dylib
+rm libGLESv2.2.dylib
+rm libGLESv2.dylib
+rm libGLU.1.dylib
+rm libGLU.dylib
+rm libICE.6.dylib
+rm libICE.dylib
+rm libOSMesa.8.dylib
+rm libOSMesa.dylib
+rm libSM.6.dylib
+rm libSM.dylib
+rm libX11-xcb.1.dylib
+rm libX11-xcb.dylib
+rm libX11.6.dylib
+rm libX11.dylib
+rm libXau.6.dylib
+rm libXau.dylib
+rm libXcomposite.1.dylib
+rm libXcomposite.dylib
+rm libXcursor.1.dylib
+rm libXcursor.dylib
+rm libXdamage.1.dylib
+rm libXdamage.dylib
+rm libXdmcp.6.dylib
+rm libXdmcp.dylib
+rm libXext.6.dylib
+rm libXext.dylib
+rm libXfixes.3.dylib
+rm libXfixes.dylib
+rm libXft.2.dylib
+rm libXft.dylib
+rm libXi.6.dylib
+rm libXi.dylib
+rm libXinerama.1.dylib
+rm libXinerama.dylib
+rm libXmu.6.dylib
+rm libXmu.dylib
+rm libXmuu.1.dylib
+rm libXmuu.dylib
+rm libXrandr.2.dylib
+rm libXrandr.dylib
+rm libXrender.1.dylib
+rm libXrender.dylib
+rm libXt.6.dylib
+rm libXt.dylib
+rm libXv.1.dylib
+rm libXv.dylib
+rm libXxf86vm.1.dylib
+rm libXxf86vm.dylib
+rm libcairo-gobject.2.dylib
+rm libcairo-gobject.dylib
+rm libcairo-script-interpreter.2.dylib
+rm libcairo-script-interpreter.dylib
+rm libcairo.2.dylib
+rm libcairo.dylib
+rm libglapi.0.dylib
+rm libglapi.dylib
+rm libpixman-1.0.dylib
+rm libpixman-1.dylib
+rm libxcb-composite.0.dylib
+rm libxcb-composite.dylib
+rm libxcb-damage.0.dylib
+rm libxcb-damage.dylib
+rm libxcb-dpms.0.dylib
+rm libxcb-dpms.dylib
+rm libxcb-dri2.0.dylib
+rm libxcb-dri2.dylib
+rm libxcb-dri3.0.dylib
+rm libxcb-dri3.dylib
+rm libxcb-glx.0.dylib
+rm libxcb-glx.dylib
+rm libxcb-present.0.dylib
+rm libxcb-present.dylib
+rm libxcb-randr.0.dylib
+rm libxcb-randr.dylib
+rm libxcb-record.0.dylib
+rm libxcb-record.dylib
+rm libxcb-render.0.dylib
+rm libxcb-render.dylib
+rm libxcb-res.0.dylib
+rm libxcb-res.dylib
+rm libxcb-screensaver.0.dylib
+rm libxcb-screensaver.dylib
+rm libxcb-shape.0.dylib
+rm libxcb-shape.dylib
+rm libxcb-shm.0.dylib
+rm libxcb-shm.dylib
+rm libxcb-sync.1.dylib
+rm libxcb-sync.dylib
+rm libxcb-util.1.dylib
+rm libxcb-util.dylib
+rm libxcb-xf86dri.0.dylib
+rm libxcb-xf86dri.dylib
+rm libxcb-xfixes.0.dylib
+rm libxcb-xfixes.dylib
+rm libxcb-xinerama.0.dylib
+rm libxcb-xinerama.dylib
+rm libxcb-xinput.0.dylib
+rm libxcb-xinput.dylib
+rm libxcb-xkb.1.dylib
+rm libxcb-xkb.dylib
+rm libxcb-xtest.0.dylib
+rm libxcb-xtest.dylib
+rm libxcb-xv.0.dylib
+rm libxcb-xv.dylib
+rm libxcb-xvmc.0.dylib
+rm libxcb-xvmc.dylib
+rm libxcb.1.dylib
+rm libxcb.dylib
+rm libxslt.1.dylib
+rm libxslt.dylib
+
 ## Fixing imports
 bash /root/fix_imports.sh "/root/runtime"
-
-## A dependency is missing for gnutls
-cd "/root/runtime/lib"
-ln -s "libidn.12.dylib" "libidn.11.dylib"
 
 echo "[END]"

--- a/builders/scripts/builder_darwin_amd64_wine
+++ b/builders/scripts/builder_darwin_amd64_wine
@@ -36,7 +36,7 @@ chmod +x "/root/osxcross/target/bin/x86_64-apple-darwin15-gcc"
 
 ####### Install VKD3D
 echo "[STAGE 3/11] Installing vkd3d"
-bash "/root/install_vkd3d.sh" "vkd3d-1.1" || exit 4
+bash "/root/install_vkd3d.sh" "$VKD3D" || exit 4
 
 export C_INCLUDE_PATH="/root/osxcross/target/macports/pkgs/opt/local/include/:/root/osxcross/target/macports/pkgs/opt/local/include/libxml2/:/root/vkd3d/include/"
 export LIBRARY_PATH="/root/osxcross/target/macports/pkgs/opt/local/lib"
@@ -73,13 +73,126 @@ echo "[STAGE 10/11] Copying libs"
 cp -d /root/osxcross/target/macports/pkgs/opt/local/lib/*.dylib "/root/wine/lib"
 rm /root/wine/lib/libpython2.7.dylib
 
+## Remove all the XQuartz files, not needed and shrink file size!
+cd "/root/wine/lib"
+rm libGL.1.dylib
+rm libGL.dylib
+rm libGLESv1_CM.1.dylib
+rm libGLESv1_CM.dylib
+rm libGLESv2.2.dylib
+rm libGLESv2.dylib
+rm libGLU.1.dylib
+rm libGLU.dylib
+rm libICE.6.dylib
+rm libICE.dylib
+rm libOSMesa.8.dylib
+rm libOSMesa.dylib
+rm libSM.6.dylib
+rm libSM.dylib
+rm libX11-xcb.1.dylib
+rm libX11-xcb.dylib
+rm libX11.6.dylib
+rm libX11.dylib
+rm libXau.6.dylib
+rm libXau.dylib
+rm libXcomposite.1.dylib
+rm libXcomposite.dylib
+rm libXcursor.1.dylib
+rm libXcursor.dylib
+rm libXdamage.1.dylib
+rm libXdamage.dylib
+rm libXdmcp.6.dylib
+rm libXdmcp.dylib
+rm libXext.6.dylib
+rm libXext.dylib
+rm libXfixes.3.dylib
+rm libXfixes.dylib
+rm libXft.2.dylib
+rm libXft.dylib
+rm libXi.6.dylib
+rm libXi.dylib
+rm libXinerama.1.dylib
+rm libXinerama.dylib
+rm libXmu.6.dylib
+rm libXmu.dylib
+rm libXmuu.1.dylib
+rm libXmuu.dylib
+rm libXrandr.2.dylib
+rm libXrandr.dylib
+rm libXrender.1.dylib
+rm libXrender.dylib
+rm libXt.6.dylib
+rm libXt.dylib
+rm libXv.1.dylib
+rm libXv.dylib
+rm libXxf86vm.1.dylib
+rm libXxf86vm.dylib
+rm libcairo-gobject.2.dylib
+rm libcairo-gobject.dylib
+rm libcairo-script-interpreter.2.dylib
+rm libcairo-script-interpreter.dylib
+rm libcairo.2.dylib
+rm libcairo.dylib
+rm libglapi.0.dylib
+rm libglapi.dylib
+rm libpixman-1.0.dylib
+rm libpixman-1.dylib
+rm libxcb-composite.0.dylib
+rm libxcb-composite.dylib
+rm libxcb-damage.0.dylib
+rm libxcb-damage.dylib
+rm libxcb-dpms.0.dylib
+rm libxcb-dpms.dylib
+rm libxcb-dri2.0.dylib
+rm libxcb-dri2.dylib
+rm libxcb-dri3.0.dylib
+rm libxcb-dri3.dylib
+rm libxcb-glx.0.dylib
+rm libxcb-glx.dylib
+rm libxcb-present.0.dylib
+rm libxcb-present.dylib
+rm libxcb-randr.0.dylib
+rm libxcb-randr.dylib
+rm libxcb-record.0.dylib
+rm libxcb-record.dylib
+rm libxcb-render.0.dylib
+rm libxcb-render.dylib
+rm libxcb-res.0.dylib
+rm libxcb-res.dylib
+rm libxcb-screensaver.0.dylib
+rm libxcb-screensaver.dylib
+rm libxcb-shape.0.dylib
+rm libxcb-shape.dylib
+rm libxcb-shm.0.dylib
+rm libxcb-shm.dylib
+rm libxcb-sync.1.dylib
+rm libxcb-sync.dylib
+rm libxcb-util.1.dylib
+rm libxcb-util.dylib
+rm libxcb-xf86dri.0.dylib
+rm libxcb-xf86dri.dylib
+rm libxcb-xfixes.0.dylib
+rm libxcb-xfixes.dylib
+rm libxcb-xinerama.0.dylib
+rm libxcb-xinerama.dylib
+rm libxcb-xinput.0.dylib
+rm libxcb-xinput.dylib
+rm libxcb-xkb.1.dylib
+rm libxcb-xkb.dylib
+rm libxcb-xtest.0.dylib
+rm libxcb-xtest.dylib
+rm libxcb-xv.0.dylib
+rm libxcb-xv.dylib
+rm libxcb-xvmc.0.dylib
+rm libxcb-xvmc.dylib
+rm libxcb.1.dylib
+rm libxcb.dylib
+rm libxslt.1.dylib
+rm libxslt.dylib
+
 ## Fixing imports
 echo "[STAGE 11/11] Fixing imports"
 bash /root/fix_imports.sh "/root/wine"
-
-## A dependency is missing for gnutls
-cd "/root/wine/lib"
-ln -s "libidn.12.dylib" "libidn.11.dylib"
 
 ## Make symlinks in /lib64 since wine64 only checks there
 cd "/root/wine/lib64"

--- a/builders/scripts/builder_darwin_mac64_wine
+++ b/builders/scripts/builder_darwin_mac64_wine
@@ -2,11 +2,9 @@
 cp -a "/root/wine-git" "/root/wine-tools" || exit 1
 
 ####### Build Tools
-apt-get -y install libfreetype6-dev:i386
-apt-get -y install libx11-dev:i386
 echo "[STAGE 1/11] Configure tools"
 cd "/root/wine-tools"
-./configure  || exit 2
+./configure --enable-win64 || exit 2
 
 echo "[STAGE 2/11] Make tools"
 make __tooldeps__ -j 4 || exit 3
@@ -17,9 +15,7 @@ echo "$PWD/winebuild.real -m32 \"\$@\"" >> winebuild
 chmod +x winebuild
 
 ####### Build wine
-apt-get -y install libfreetype6-dev
 ### Environment preparation
-mkdir -p "/root/wine-git/wine64-build/"
 mkdir -p "/root/wine-git/wine32-build/"
 export FRAMEWORK="10.11"
 
@@ -32,7 +28,6 @@ ln -s "/root/osxcross/target/bin/x86_64-apple-darwin15-as" "/root/osxcross/targe
 ln -s "/root/osxcross/target/bin/x86_64-apple-darwin15-install_name_tool" "/root/osxcross/target/bin/install_name_tool"
 
 #### Wine
-rm -r /root/osxcross/target/macports/pkgs/opt/local/include/wine/
 export C_INCLUDE_PATH="/root/osxcross/target/macports/pkgs/opt/local/include/:/root/osxcross/target/macports/pkgs/opt/local/include/libxml2/:/root/vkd3d/include/"
 export LIBRARY_PATH="/root/osxcross/target/macports/pkgs/opt/local/lib"
 
@@ -44,16 +39,12 @@ chmod +x "/root/osxcross/target/bin/x86_64-apple-darwin15-gcc"
 echo '$CC "$@"' > "/root/osxcross/target/bin/i386-apple-darwin15-gcc"
 chmod +x "/root/osxcross/target/bin/i386-apple-darwin15-gcc"
 
-cd "/root/wine-git/"
+cd "/root/wine-git/wine32-build/"
 echo "[STAGE 6/11] Configure 32 bits"
-./configure --host i386-apple-darwin15 --prefix="/" --with-wine-tools="/root/wine-tools" LFFLAGS=" -Wl,-rpath,/opt/x11/lib -L/root/osxcross/target/macports/pkgs/opt/local/lib" || exit 7
+../configure --host i386-apple-darwin15 --prefix="/" --with-wine-tools="/root/wine-tools" LFFLAGS=" -Wl,-rpath,/opt/x11/lib -L/root/osxcross/target/macports/pkgs/opt/local/lib" || exit 7
 
 echo "[STAGE 7/11] Make 32 bits"
 make -j 4 || exit 8
-
-echo "[STAGE 8/11] Make install 64 bits"
-cd "/root/wine-git/wine64-build/"
-make install DESTDIR="/root/wine" || exit 9
 
 echo "[STAGE 9/11] Make install 32 bits"
 cd "/root/wine-git/wine32-build/"
@@ -64,16 +55,129 @@ echo "[STAGE 10/11] Copying libs"
 cp -d /root/osxcross/target/macports/pkgs/opt/local/lib/*.dylib "/root/wine/lib"
 rm /root/wine/lib/libpython2.7.dylib
 
+## Remove all the XQuartz files, not needed and shrink file size!
+cd "/root/wine/lib"
+rm libGL.1.dylib
+rm libGL.dylib
+rm libGLESv1_CM.1.dylib
+rm libGLESv1_CM.dylib
+rm libGLESv2.2.dylib
+rm libGLESv2.dylib
+rm libGLU.1.dylib
+rm libGLU.dylib
+rm libICE.6.dylib
+rm libICE.dylib
+rm libOSMesa.8.dylib
+rm libOSMesa.dylib
+rm libSM.6.dylib
+rm libSM.dylib
+rm libX11-xcb.1.dylib
+rm libX11-xcb.dylib
+rm libX11.6.dylib
+rm libX11.dylib
+rm libXau.6.dylib
+rm libXau.dylib
+rm libXcomposite.1.dylib
+rm libXcomposite.dylib
+rm libXcursor.1.dylib
+rm libXcursor.dylib
+rm libXdamage.1.dylib
+rm libXdamage.dylib
+rm libXdmcp.6.dylib
+rm libXdmcp.dylib
+rm libXext.6.dylib
+rm libXext.dylib
+rm libXfixes.3.dylib
+rm libXfixes.dylib
+rm libXft.2.dylib
+rm libXft.dylib
+rm libXi.6.dylib
+rm libXi.dylib
+rm libXinerama.1.dylib
+rm libXinerama.dylib
+rm libXmu.6.dylib
+rm libXmu.dylib
+rm libXmuu.1.dylib
+rm libXmuu.dylib
+rm libXrandr.2.dylib
+rm libXrandr.dylib
+rm libXrender.1.dylib
+rm libXrender.dylib
+rm libXt.6.dylib
+rm libXt.dylib
+rm libXv.1.dylib
+rm libXv.dylib
+rm libXxf86vm.1.dylib
+rm libXxf86vm.dylib
+rm libcairo-gobject.2.dylib
+rm libcairo-gobject.dylib
+rm libcairo-script-interpreter.2.dylib
+rm libcairo-script-interpreter.dylib
+rm libcairo.2.dylib
+rm libcairo.dylib
+rm libglapi.0.dylib
+rm libglapi.dylib
+rm libpixman-1.0.dylib
+rm libpixman-1.dylib
+rm libxcb-composite.0.dylib
+rm libxcb-composite.dylib
+rm libxcb-damage.0.dylib
+rm libxcb-damage.dylib
+rm libxcb-dpms.0.dylib
+rm libxcb-dpms.dylib
+rm libxcb-dri2.0.dylib
+rm libxcb-dri2.dylib
+rm libxcb-dri3.0.dylib
+rm libxcb-dri3.dylib
+rm libxcb-glx.0.dylib
+rm libxcb-glx.dylib
+rm libxcb-present.0.dylib
+rm libxcb-present.dylib
+rm libxcb-randr.0.dylib
+rm libxcb-randr.dylib
+rm libxcb-record.0.dylib
+rm libxcb-record.dylib
+rm libxcb-render.0.dylib
+rm libxcb-render.dylib
+rm libxcb-res.0.dylib
+rm libxcb-res.dylib
+rm libxcb-screensaver.0.dylib
+rm libxcb-screensaver.dylib
+rm libxcb-shape.0.dylib
+rm libxcb-shape.dylib
+rm libxcb-shm.0.dylib
+rm libxcb-shm.dylib
+rm libxcb-sync.1.dylib
+rm libxcb-sync.dylib
+rm libxcb-util.1.dylib
+rm libxcb-util.dylib
+rm libxcb-xf86dri.0.dylib
+rm libxcb-xf86dri.dylib
+rm libxcb-xfixes.0.dylib
+rm libxcb-xfixes.dylib
+rm libxcb-xinerama.0.dylib
+rm libxcb-xinerama.dylib
+rm libxcb-xinput.0.dylib
+rm libxcb-xinput.dylib
+rm libxcb-xkb.1.dylib
+rm libxcb-xkb.dylib
+rm libxcb-xtest.0.dylib
+rm libxcb-xtest.dylib
+rm libxcb-xv.0.dylib
+rm libxcb-xv.dylib
+rm libxcb-xvmc.0.dylib
+rm libxcb-xvmc.dylib
+rm libxcb.1.dylib
+rm libxcb.dylib
+rm libxslt.1.dylib
+rm libxslt.dylib
+
 ## Fixing imports
 echo "[STAGE 11/11] Fixing imports"
 bash /root/fix_imports.sh "/root/wine"
 
-## A dependency is missing for gnutls
-cd "/root/wine/lib"
-ln -s "libidn.12.dylib" "libidn.11.dylib"
-
 ## Make symlinks in /lib64 since wine64 only checks there
-cd "/root/wine/lib64"
-ln -s ../lib/*.dylib .
+#cd "/root/wine/lib64"
+#ln -s ../lib/*.dylib .
 
 echo "[END]"

--- a/builders/scripts/builder_darwin_x86_runtime
+++ b/builders/scripts/builder_darwin_x86_runtime
@@ -2,7 +2,6 @@
 ln -s "/root/osxcross/target/bin/i386-apple-darwin15-install_name_tool" "/root/osxcross/target/bin/install_name_tool"
 ln -s "/root/osxcross/target/bin/i386-apple-darwin15-otool" "/root/osxcross/target/bin/otool"
 
-
 mkdir -p /root/runtime/lib
 cd "/root/runtime/lib/"
 
@@ -10,12 +9,125 @@ cd "/root/runtime/lib/"
 cp -d /root/osxcross/target/macports/pkgs/opt/local/lib/*.dylib "/root/runtime/lib"
 rm /root/runtime/lib/libpython2.7.dylib
 
+## Remove all the XQuartz files, not needed and shrink file size!
+cd "/root/runtime/lib"
+rm libGL.1.dylib
+rm libGL.dylib
+rm libGLESv1_CM.1.dylib
+rm libGLESv1_CM.dylib
+rm libGLESv2.2.dylib
+rm libGLESv2.dylib
+rm libGLU.1.dylib
+rm libGLU.dylib
+rm libICE.6.dylib
+rm libICE.dylib
+rm libOSMesa.8.dylib
+rm libOSMesa.dylib
+rm libSM.6.dylib
+rm libSM.dylib
+rm libX11-xcb.1.dylib
+rm libX11-xcb.dylib
+rm libX11.6.dylib
+rm libX11.dylib
+rm libXau.6.dylib
+rm libXau.dylib
+rm libXcomposite.1.dylib
+rm libXcomposite.dylib
+rm libXcursor.1.dylib
+rm libXcursor.dylib
+rm libXdamage.1.dylib
+rm libXdamage.dylib
+rm libXdmcp.6.dylib
+rm libXdmcp.dylib
+rm libXext.6.dylib
+rm libXext.dylib
+rm libXfixes.3.dylib
+rm libXfixes.dylib
+rm libXft.2.dylib
+rm libXft.dylib
+rm libXi.6.dylib
+rm libXi.dylib
+rm libXinerama.1.dylib
+rm libXinerama.dylib
+rm libXmu.6.dylib
+rm libXmu.dylib
+rm libXmuu.1.dylib
+rm libXmuu.dylib
+rm libXrandr.2.dylib
+rm libXrandr.dylib
+rm libXrender.1.dylib
+rm libXrender.dylib
+rm libXt.6.dylib
+rm libXt.dylib
+rm libXv.1.dylib
+rm libXv.dylib
+rm libXxf86vm.1.dylib
+rm libXxf86vm.dylib
+rm libcairo-gobject.2.dylib
+rm libcairo-gobject.dylib
+rm libcairo-script-interpreter.2.dylib
+rm libcairo-script-interpreter.dylib
+rm libcairo.2.dylib
+rm libcairo.dylib
+rm libglapi.0.dylib
+rm libglapi.dylib
+rm libpixman-1.0.dylib
+rm libpixman-1.dylib
+rm libxcb-composite.0.dylib
+rm libxcb-composite.dylib
+rm libxcb-damage.0.dylib
+rm libxcb-damage.dylib
+rm libxcb-dpms.0.dylib
+rm libxcb-dpms.dylib
+rm libxcb-dri2.0.dylib
+rm libxcb-dri2.dylib
+rm libxcb-dri3.0.dylib
+rm libxcb-dri3.dylib
+rm libxcb-glx.0.dylib
+rm libxcb-glx.dylib
+rm libxcb-present.0.dylib
+rm libxcb-present.dylib
+rm libxcb-randr.0.dylib
+rm libxcb-randr.dylib
+rm libxcb-record.0.dylib
+rm libxcb-record.dylib
+rm libxcb-render.0.dylib
+rm libxcb-render.dylib
+rm libxcb-res.0.dylib
+rm libxcb-res.dylib
+rm libxcb-screensaver.0.dylib
+rm libxcb-screensaver.dylib
+rm libxcb-shape.0.dylib
+rm libxcb-shape.dylib
+rm libxcb-shm.0.dylib
+rm libxcb-shm.dylib
+rm libxcb-sync.1.dylib
+rm libxcb-sync.dylib
+rm libxcb-util.1.dylib
+rm libxcb-util.dylib
+rm libxcb-xf86dri.0.dylib
+rm libxcb-xf86dri.dylib
+rm libxcb-xfixes.0.dylib
+rm libxcb-xfixes.dylib
+rm libxcb-xinerama.0.dylib
+rm libxcb-xinerama.dylib
+rm libxcb-xinput.0.dylib
+rm libxcb-xinput.dylib
+rm libxcb-xkb.1.dylib
+rm libxcb-xkb.dylib
+rm libxcb-xtest.0.dylib
+rm libxcb-xtest.dylib
+rm libxcb-xv.0.dylib
+rm libxcb-xv.dylib
+rm libxcb-xvmc.0.dylib
+rm libxcb-xvmc.dylib
+rm libxcb.1.dylib
+rm libxcb.dylib
+rm libxslt.1.dylib
+rm libxslt.dylib
+
 ## Fixing imports
 bash /root/fix_imports.sh "/root/runtime"
-
-## A dependency is missing for gnutls
-cd "/root/runtime/lib"
-ln -s "libidn.12.dylib" "libidn.11.dylib"
 
 ## To make package smaller, we are only going to keep i386 part of the libraries
 for file in *.dylib; do

--- a/builders/scripts/builder_darwin_x86_wine
+++ b/builders/scripts/builder_darwin_x86_wine
@@ -55,13 +55,126 @@ make install DESTDIR="/root/wine" || exit 7
 cp -d /root/osxcross/target/macports/pkgs/opt/local/lib/*.dylib "/root/wine/lib"
 rm /root/wine/lib/libpython2.7.dylib
 
+## Remove all the XQuartz files, not needed and shrink file size!
+cd "/root/wine/lib"
+rm libGL.1.dylib
+rm libGL.dylib
+rm libGLESv1_CM.1.dylib
+rm libGLESv1_CM.dylib
+rm libGLESv2.2.dylib
+rm libGLESv2.dylib
+rm libGLU.1.dylib
+rm libGLU.dylib
+rm libICE.6.dylib
+rm libICE.dylib
+rm libOSMesa.8.dylib
+rm libOSMesa.dylib
+rm libSM.6.dylib
+rm libSM.dylib
+rm libX11-xcb.1.dylib
+rm libX11-xcb.dylib
+rm libX11.6.dylib
+rm libX11.dylib
+rm libXau.6.dylib
+rm libXau.dylib
+rm libXcomposite.1.dylib
+rm libXcomposite.dylib
+rm libXcursor.1.dylib
+rm libXcursor.dylib
+rm libXdamage.1.dylib
+rm libXdamage.dylib
+rm libXdmcp.6.dylib
+rm libXdmcp.dylib
+rm libXext.6.dylib
+rm libXext.dylib
+rm libXfixes.3.dylib
+rm libXfixes.dylib
+rm libXft.2.dylib
+rm libXft.dylib
+rm libXi.6.dylib
+rm libXi.dylib
+rm libXinerama.1.dylib
+rm libXinerama.dylib
+rm libXmu.6.dylib
+rm libXmu.dylib
+rm libXmuu.1.dylib
+rm libXmuu.dylib
+rm libXrandr.2.dylib
+rm libXrandr.dylib
+rm libXrender.1.dylib
+rm libXrender.dylib
+rm libXt.6.dylib
+rm libXt.dylib
+rm libXv.1.dylib
+rm libXv.dylib
+rm libXxf86vm.1.dylib
+rm libXxf86vm.dylib
+rm libcairo-gobject.2.dylib
+rm libcairo-gobject.dylib
+rm libcairo-script-interpreter.2.dylib
+rm libcairo-script-interpreter.dylib
+rm libcairo.2.dylib
+rm libcairo.dylib
+rm libglapi.0.dylib
+rm libglapi.dylib
+rm libpixman-1.0.dylib
+rm libpixman-1.dylib
+rm libxcb-composite.0.dylib
+rm libxcb-composite.dylib
+rm libxcb-damage.0.dylib
+rm libxcb-damage.dylib
+rm libxcb-dpms.0.dylib
+rm libxcb-dpms.dylib
+rm libxcb-dri2.0.dylib
+rm libxcb-dri2.dylib
+rm libxcb-dri3.0.dylib
+rm libxcb-dri3.dylib
+rm libxcb-glx.0.dylib
+rm libxcb-glx.dylib
+rm libxcb-present.0.dylib
+rm libxcb-present.dylib
+rm libxcb-randr.0.dylib
+rm libxcb-randr.dylib
+rm libxcb-record.0.dylib
+rm libxcb-record.dylib
+rm libxcb-render.0.dylib
+rm libxcb-render.dylib
+rm libxcb-res.0.dylib
+rm libxcb-res.dylib
+rm libxcb-screensaver.0.dylib
+rm libxcb-screensaver.dylib
+rm libxcb-shape.0.dylib
+rm libxcb-shape.dylib
+rm libxcb-shm.0.dylib
+rm libxcb-shm.dylib
+rm libxcb-sync.1.dylib
+rm libxcb-sync.dylib
+rm libxcb-util.1.dylib
+rm libxcb-util.dylib
+rm libxcb-xf86dri.0.dylib
+rm libxcb-xf86dri.dylib
+rm libxcb-xfixes.0.dylib
+rm libxcb-xfixes.dylib
+rm libxcb-xinerama.0.dylib
+rm libxcb-xinerama.dylib
+rm libxcb-xinput.0.dylib
+rm libxcb-xinput.dylib
+rm libxcb-xkb.1.dylib
+rm libxcb-xkb.dylib
+rm libxcb-xtest.0.dylib
+rm libxcb-xtest.dylib
+rm libxcb-xv.0.dylib
+rm libxcb-xv.dylib
+rm libxcb-xvmc.0.dylib
+rm libxcb-xvmc.dylib
+rm libxcb.1.dylib
+rm libxcb.dylib
+rm libxslt.1.dylib
+rm libxslt.dylib
+
 ## Fixing imports
 echo "[STAGE 8/8] Fixing imports"
 bash /root/fix_imports.sh "/root/wine"
-
-## A dependency is missing for gnutls
-cd "/root/wine/lib"
-ln -s "libidn.12.dylib" "libidn.11.dylib"
 
 ## To make package smaller, we are only going to keep i386 part of the libraries
 cd "/root/wine/lib/"

--- a/environments/darwin/install_vkd3d.sh
+++ b/environments/darwin/install_vkd3d.sh
@@ -2,10 +2,10 @@
 git clone "https://source.winehq.org/git/vkd3d.git/" "/root/vkd3d"
 
 cd "/root/vkd3d"
-git checkout -f "vkd3d-1.1"
+git checkout -f "$@"
 
-export C_INCLUDE_PATH="/root/osxcross/target/macports/pkgs/opt/local/include/:/root/osxcross/target/macports/pkgs/opt/local/include/libxml2/:/root/vulkansdk-macos-1.1.101.0/macOS/include/:/root/SPIRV-Headers/include/:/root/SPIRV-Headers/include/spirv/"
-export LIBRARY_PATH="/root/osxcross/target/macports/pkgs/opt/local/lib:/root/vulkansdk-macos-1.1.101.0/macOS/lib/"
+export C_INCLUDE_PATH="/root/osxcross/target/macports/pkgs/opt/local/include/:/root/osxcross/target/macports/pkgs/opt/local/include/libxml2/:/root/vulkansdk-macos-${MOLTENVK}/macOS/include/:/root/SPIRV-Headers/include/:/root/SPIRV-Headers/include/spirv/"
+export LIBRARY_PATH="/root/osxcross/target/macports/pkgs/opt/local/lib:/root/vulkansdk-macos-${MOLTENVK}/macOS/lib/"
 export PATH="/root/wine-tools/tools/widl/:$PATH"
 
 ./autogen.sh || exit 1

--- a/environments/linux-amd64-wine_osxcross
+++ b/environments/linux-amd64-wine_osxcross
@@ -14,26 +14,25 @@ RUN apt-get -y install libjs-mathjax python-yaml lib32gcc1 lib32stdc++6 libc6-i3
 RUN dpkg -i *.deb
 
 RUN git clone https://github.com/tpoechtrager/osxcross /root/osxcross
-
 COPY darwin/SDK/MacOSX10.11.sdk.tar.xz /root/osxcross/tarballs/
-
 RUN cd /root/osxcross && UNATTENDED=1 ./build.sh
 
 ENV PATH="/root/osxcross/target/bin:${PATH}"
 ENV MACOSX_DEPLOYMENT_TARGET="10.11"
+ENV FRAMEWORK="10.11"
+ENV FAUDIO="19.05"
+ENV MOLTENVK="1.1.106.0"
+ENV VKD3D="vkd3d-1.1"
 
 RUN mkdir -p /root/osxcross/target/macports
 RUN printf "packages.macports.org" > /root/osxcross/target/macports/MIRROR
 
-RUN osxcross-macports -universal fakeinstall -v pulseaudio
-
 # We need to compile ncurses by ourselves (see above) to avoid terminals database is inaccessible error
 # This will prevent wine-devel from installing it
-RUN env osxcross-macports -universal fakeinstall ncurses
-
-RUN osxcross-macports -universal install -v wine-devel
-RUN osxcross-macports -universal install gnutls
-# RUN env MACOSX_DEPLOYMENT_TARGET=10.12 osxcross-macports install MoltenVK
+RUN osxcross-macports -universal fakeinstall ncurses
+RUN osxcross-macports -universal fakeinstall pulseaudio
+RUN osxcross-macports -universal install wine-devel
+# RUN osxcross-macports -universal install gnutls
 
 # Lets make folders to keep compiled libs inside
 RUN mkdir /root/osxcross/target/macports/pkgs/opt/local/lib32
@@ -47,7 +46,6 @@ WORKDIR /root/ncurses
 RUN wget https://ftp.gnu.org/pub/gnu/ncurses/ncurses-6.1.tar.gz
 RUN tar -xvf  ncurses-6.1.tar.gz
 WORKDIR /root/ncurses/ncurses-6.1
-ENV FRAMEWORK="10.11"
 
 ### NCurses 32Bit
 RUN ln -s "/root/osxcross/target/bin/i386-apple-darwin15-strip" "/root/osxcross/target/bin/strip"
@@ -78,7 +76,6 @@ WORKDIR /root/sdl2
 RUN wget https://www.libsdl.org/release/SDL2-2.0.9.tar.gz
 RUN tar -xvf  SDL2-2.0.9.tar.gz
 WORKDIR /root/sdl2/SDL2-2.0.9
-ENV FRAMEWORK="10.11"
 
 ### SDL2 32Bit
 RUN ln -s "/root/osxcross/target/bin/i386-apple-darwin15-strip" "/root/osxcross/target/bin/strip"
@@ -108,25 +105,16 @@ RUN x86_64-apple-darwin15-lipo /root/osxcross/target/macports/pkgs/opt/local/lib
 
 ### Vulkan
 WORKDIR /root/
-RUN wget https://sdk.lunarg.com/sdk/download/1.1.101.0/mac/vulkansdk-macos-1.1.101.0.tar.gz
-RUN tar -xvf vulkansdk-macos-1.1.101.0.tar.gz
+RUN wget https://sdk.lunarg.com/sdk/download/${MOLTENVK}/mac/vulkansdk-macos-${MOLTENVK}.tar.gz
+RUN tar -xvf vulkansdk-macos-${MOLTENVK}.tar.gz
 
-WORKDIR /root/vulkansdk-macos-1.1.101.0/MoltenVK/include
+WORKDIR /root/vulkansdk-macos-${MOLTENVK}/MoltenVK/include
 RUN mv MoltenVK /root/osxcross/target/macports/pkgs/opt/local/include/
 
-WORKDIR /root/vulkansdk-macos-1.1.101.0/MoltenVK/macOS
+WORKDIR /root/vulkansdk-macos-${MOLTENVK}/MoltenVK/macOS
 RUN mv framework/* /root/osxcross/target/macports/pkgs/opt/local/Library/Frameworks/
 RUN mv static/* /root/osxcross/target/macports/pkgs/opt/local/lib/
 RUN mv dynamic/* /root/osxcross/target/macports/pkgs/opt/local/lib/
-
-# WORKDIR /root/vulkansdk-macos-11.1.101.0/macOS
-# RUN mv Frameworks/vulkan.framework/ /root/osxcross/target/macports/pkgs/opt/local/Library/Frameworks/
-# RUN mv bin/* /root/osxcross/target/macports/pkgs/opt/local/bin/
-# RUN mv etc/* /root/osxcross/target/macports/pkgs/opt/local/etc/
-# RUN mv lib/pkgconfig/* /root/osxcross/target/macports/pkgs/opt/local/lib/pkgconfig/
-# RUN rmdir lib/pkgconfig/
-# RUN mv lib/* /root/osxcross/target/macports/pkgs/opt/local/lib/
-# RUN mv include/* /root/osxcross/target/macports/pkgs/opt/local/include/
 
 ### VK3D3
 WORKDIR /root
@@ -138,9 +126,9 @@ COPY darwin/install_vkd3d.sh /root/
 COPY darwin/fix_imports.sh /root/
 
 ## MS Hook Prologue support
-RUN mkdir /root/ms_hook_prologue
-COPY ms_hook_prologue/*.patch /root/ms_hook_prologue/
-COPY ms_hook_prologue/install_clang_ms_hook_prologue_support.sh /root/ms_hook_prologue/
+RUN mkdir /root/clang_ms_hook_prologue
+COPY ms_hook_prologue/*.patch /root/clang_ms_hook_prologue/
+COPY ms_hook_prologue/install_clang_ms_hook_prologue_support.sh /root/
 # RUN bash /root/install_clang_ms_hook_prologue_support.sh
 
 # Faudio
@@ -148,30 +136,27 @@ RUN ln -s "/root/osxcross/target/bin/i386-apple-darwin15-ld" "/root/osxcross/tar
 RUN apt-get -y install cmake
 RUN mkdir -p /root/faudio
 WORKDIR /root/faudio
-RUN git clone https://github.com/FNA-XNA/FAudio
+RUN git clone -b "${FAUDIO}" https://github.com/FNA-XNA/FAudio
 RUN mkdir -p /root/faudio/build64
 RUN mkdir -p /root/faudio/build32
 RUN mkdir -p /root/faudio/build
 WORKDIR /root/faudio/build64
-RUN env SDL2_DIR=/root/osxcross/target/macports/pkgs/opt/local/lib/cmake/SDL2 env CFLAGS="-O3 -msse2 -target x86_64-apple-darwin15 -mmacosx-version-min=10.8 -B/root/osxcross/target/bin/ -isysroot/root/osxcross/target/SDK/MacOSX10.11.sdk/ -F/root/osxcross/target/macports/pkgs/opt/local/Library/Frameworks/" cmake /root/faudio/FAudio -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang -DBUILD_CPP=OFF -DCMAKE_OSX_SYSROOT=/root/osxcross/target/SDK/MacOSX10.11.sdk  -DCMAKE_SYSTEM_NAME=Darwin -DCMAKE_FIND_ROOT_PATH=/root/osxcross/target/macports/pkgs/opt/local/
+RUN env SDL2_DIR=/root/osxcross/target/macports/pkgs/opt/local/lib/cmake/SDL2 env CFLAGS="-O3 -msse2 -target x86_64-apple-darwin15 -mmacosx-version-min=10.8 -B/root/osxcross/target/bin/ -isysroot/root/osxcross/target/SDK/MacOSX$FRAMEWORK.sdk/ -F/root/osxcross/target/macports/pkgs/opt/local/Library/Frameworks/" cmake /root/faudio/FAudio -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang -DBUILD_CPP=OFF -DCMAKE_OSX_SYSROOT=/root/osxcross/target/SDK/MacOSX$FRAMEWORK.sdk  -DCMAKE_SYSTEM_NAME=Darwin -DCMAKE_FIND_ROOT_PATH=/root/osxcross/target/macports/pkgs/opt/local/
 RUN make
 RUN make install DESTDIR=install/
 RUN cp install/usr/local/include/* /root/osxcross/target/macports/pkgs/opt/local/include
 
 WORKDIR /root/faudio/build32
-RUN env SDL2_DIR=/root/osxcross/target/macports/pkgs/opt/local/lib/cmake/SDL2 env CFLAGS="-O3 -msse2 -target i386-apple-darwin15 -mmacosx-version-min=10.8 -B/root/osxcross/target/bin/ -isysroot/root/osxcross/target/SDK/MacOSX10.11.sdk/ -F/root/osxcross/target/macports/pkgs/opt/local/Library/Frameworks/" cmake /root/faudio/FAudio -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang -DBUILD_CPP=OFF -DCMAKE_OSX_SYSROOT=/root/osxcross/target/SDK/MacOSX10.11.sdk  -DCMAKE_SYSTEM_NAME=Darwin -DCMAKE_FIND_ROOT_PATH=/root/osxcross/target/macports/pkgs/opt/local/
+RUN env SDL2_DIR=/root/osxcross/target/macports/pkgs/opt/local/lib/cmake/SDL2 env CFLAGS="-O3 -msse2 -target i386-apple-darwin15 -mmacosx-version-min=10.8 -B/root/osxcross/target/bin/ -isysroot/root/osxcross/target/SDK/MacOSX$FRAMEWORK.sdk/ -F/root/osxcross/target/macports/pkgs/opt/local/Library/Frameworks/" cmake /root/faudio/FAudio -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang -DBUILD_CPP=OFF -DCMAKE_OSX_SYSROOT=/root/osxcross/target/SDK/MacOSX$FRAMEWORK.sdk  -DCMAKE_SYSTEM_NAME=Darwin -DCMAKE_FIND_ROOT_PATH=/root/osxcross/target/macports/pkgs/opt/local/
 RUN make
 WORKDIR /root/faudio/build
-RUN x86_64-apple-darwin15-lipo ../build32/libFAudio.0.19.05.dylib ../build64/libFAudio.0.19.05.dylib -output libFAudio.0.19.05.dylib -create
-RUN ln -s libFAudio.0.19.05.dylib libFAudio.dylib
-RUN ln -s libFAudio.0.19.05.dylib libFAudio.0.dylib
+RUN x86_64-apple-darwin15-lipo ../build32/libFAudio.0.$FAUDIO.dylib ../build64/libFAudio.0.$FAUDIO.dylib -output libFAudio.0.$FAUDIO.dylib -create
+RUN ln -s libFAudio.0.$FAUDIO.dylib libFAudio.dylib
+RUN ln -s libFAudio.0.$FAUDIO.dylib libFAudio.0.dylib
 RUN cp -d *.dylib /root/osxcross/target/macports/pkgs/opt/local/lib
 RUN rm "/root/osxcross/target/bin/ld"
 
 ## Removing preinstalled wine libs to prevent conflict
 RUN rm /root/osxcross/target/macports/pkgs/opt/local/lib/libwine.*
 RUN rm -r /root/osxcross/target/macports/pkgs/opt/local/lib/wine
-
-RUN dpkg --add-architecture i386
-RUN apt-get update
-RUN apt-get -y install libc6-dev:i386 gcc-multilib libfreetype6:i386
+RUN rm -r /root/osxcross/target/macports/pkgs/opt/local/include/wine/

--- a/environments/linux-x86-wine_osxcross
+++ b/environments/linux-x86-wine_osxcross
@@ -9,26 +9,25 @@ RUN apt-get -y build-dep wine
 RUN apt-get -y install git llvm clang wget
 
 RUN git clone https://github.com/tpoechtrager/osxcross /root/osxcross
-
 COPY darwin/SDK/MacOSX10.11.sdk.tar.xz /root/osxcross/tarballs/
-
 RUN cd /root/osxcross && UNATTENDED=1 ./build.sh
 
 ENV PATH="/root/osxcross/target/bin:${PATH}"
 ENV MACOSX_DEPLOYMENT_TARGET="10.11"
+ENV FRAMEWORK="10.11"
+ENV FAUDIO="19.05"
+ENV MOLTENVK="1.1.106.0"
+ENV VKD3D="vkd3d-1.1"
 
 RUN mkdir -p /root/osxcross/target/macports
 RUN printf "packages.macports.org" > /root/osxcross/target/macports/MIRROR
 
-RUN osxcross-macports -universal fakeinstall -v pulseaudio
-
 # We need to compile ncurses by ourselves (see above) to avoid terminals database is inaccessible error
 # This will prevent wine-devel from installing it
-RUN env osxcross-macports -universal fakeinstall ncurses
-
-RUN osxcross-macports -universal install -v wine-devel
-RUN osxcross-macports -universal install gnutls
-# RUN env MACOSX_DEPLOYMENT_TARGET=10.12 osxcross-macports install MoltenVK
+RUN osxcross-macports -universal fakeinstall ncurses
+RUN osxcross-macports -universal fakeinstall pulseaudio
+RUN osxcross-macports -universal install wine-devel
+# RUN osxcross-macports -universal install gnutls
 
 # Lets make folders to keep compiled libs inside
 RUN mkdir /root/osxcross/target/macports/pkgs/opt/local/lib32
@@ -42,7 +41,6 @@ WORKDIR /root/ncurses
 RUN wget https://ftp.gnu.org/pub/gnu/ncurses/ncurses-6.1.tar.gz
 RUN tar -xvf  ncurses-6.1.tar.gz
 WORKDIR /root/ncurses/ncurses-6.1
-ENV FRAMEWORK="10.11"
 
 ### NCurses 32Bit
 RUN ln -s "/root/osxcross/target/bin/i386-apple-darwin15-strip" "/root/osxcross/target/bin/strip"
@@ -73,7 +71,6 @@ WORKDIR /root/sdl2
 RUN wget https://www.libsdl.org/release/SDL2-2.0.9.tar.gz
 RUN tar -xvf  SDL2-2.0.9.tar.gz
 WORKDIR /root/sdl2/SDL2-2.0.9
-ENV FRAMEWORK="10.11"
 
 ### SDL2 32Bit
 RUN ln -s "/root/osxcross/target/bin/i386-apple-darwin15-strip" "/root/osxcross/target/bin/strip"
@@ -103,25 +100,16 @@ RUN x86_64-apple-darwin15-lipo /root/osxcross/target/macports/pkgs/opt/local/lib
 
 ### Vulkan
 WORKDIR /root/
-RUN wget https://sdk.lunarg.com/sdk/download/1.1.101.0/mac/vulkansdk-macos-1.1.101.0.tar.gz
-RUN tar -xvf vulkansdk-macos-1.1.101.0.tar.gz
+RUN wget https://sdk.lunarg.com/sdk/download/${MOLTENVK}/mac/vulkansdk-macos-${MOLTENVK}.tar.gz
+RUN tar -xvf vulkansdk-macos-${MOLTENVK}.tar.gz
 
-WORKDIR /root/vulkansdk-macos-1.1.101.0/MoltenVK/include
+WORKDIR /root/vulkansdk-macos-${MOLTENVK}/MoltenVK/include
 RUN mv MoltenVK /root/osxcross/target/macports/pkgs/opt/local/include/
 
-WORKDIR /root/vulkansdk-macos-1.1.101.0/MoltenVK/macOS
+WORKDIR /root/vulkansdk-macos-${MOLTENVK}/MoltenVK/macOS
 RUN mv framework/* /root/osxcross/target/macports/pkgs/opt/local/Library/Frameworks/
 RUN mv static/* /root/osxcross/target/macports/pkgs/opt/local/lib/
 RUN mv dynamic/* /root/osxcross/target/macports/pkgs/opt/local/lib/
-
-# WORKDIR /root/vulkansdk-macos-11.1.101.0/macOS
-# RUN mv Frameworks/vulkan.framework/ /root/osxcross/target/macports/pkgs/opt/local/Library/Frameworks/
-# RUN mv bin/* /root/osxcross/target/macports/pkgs/opt/local/bin/
-# RUN mv etc/* /root/osxcross/target/macports/pkgs/opt/local/etc/
-# RUN mv lib/pkgconfig/* /root/osxcross/target/macports/pkgs/opt/local/lib/pkgconfig/
-# RUN rmdir lib/pkgconfig/
-# RUN mv lib/* /root/osxcross/target/macports/pkgs/opt/local/lib/
-# RUN mv include/* /root/osxcross/target/macports/pkgs/opt/local/include/
 
 ### VK3D3
 WORKDIR /root
@@ -133,9 +121,9 @@ COPY darwin/install_vkd3d.sh /root/
 COPY darwin/fix_imports.sh /root/
 
 ## MS Hook Prologue support
-RUN mkdir /root/ms_hook_prologue
-COPY ms_hook_prologue/*.patch /root/ms_hook_prologue/
-COPY ms_hook_prologue/install_clang_ms_hook_prologue_support.sh /root/ms_hook_prologue/
+RUN mkdir /root/clang_ms_hook_prologue
+COPY ms_hook_prologue/*.patch /root/clang_ms_hook_prologue/
+COPY ms_hook_prologue/install_clang_ms_hook_prologue_support.sh /root/
 # RUN bash /root/install_clang_ms_hook_prologue_support.sh
 
 # Faudio
@@ -143,27 +131,27 @@ RUN ln -s "/root/osxcross/target/bin/i386-apple-darwin15-ld" "/root/osxcross/tar
 RUN apt-get -y install cmake
 RUN mkdir -p /root/faudio
 WORKDIR /root/faudio
-RUN git clone https://github.com/FNA-XNA/FAudio
+RUN git clone -b "${FAUDIO}" https://github.com/FNA-XNA/FAudio
 RUN mkdir -p /root/faudio/build64
 RUN mkdir -p /root/faudio/build32
 RUN mkdir -p /root/faudio/build
 WORKDIR /root/faudio/build64
-RUN env SDL2_DIR=/root/osxcross/target/macports/pkgs/opt/local/lib/cmake/SDL2 env CFLAGS="-O3 -msse2 -target x86_64-apple-darwin15 -mmacosx-version-min=10.8 -B/root/osxcross/target/bin/ -isysroot/root/osxcross/target/SDK/MacOSX10.11.sdk/ -F/root/osxcross/target/macports/pkgs/opt/local/Library/Frameworks/" cmake /root/faudio/FAudio -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang -DBUILD_CPP=OFF -DCMAKE_OSX_SYSROOT=/root/osxcross/target/SDK/MacOSX10.11.sdk  -DCMAKE_SYSTEM_NAME=Darwin -DCMAKE_FIND_ROOT_PATH=/root/osxcross/target/macports/pkgs/opt/local/
+RUN env SDL2_DIR=/root/osxcross/target/macports/pkgs/opt/local/lib/cmake/SDL2 env CFLAGS="-O3 -msse2 -target x86_64-apple-darwin15 -mmacosx-version-min=10.8 -B/root/osxcross/target/bin/ -isysroot/root/osxcross/target/SDK/MacOSX$FRAMEWORK.sdk/ -F/root/osxcross/target/macports/pkgs/opt/local/Library/Frameworks/" cmake /root/faudio/FAudio -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang -DBUILD_CPP=OFF -DCMAKE_OSX_SYSROOT=/root/osxcross/target/SDK/MacOSX$FRAMEWORK.sdk  -DCMAKE_SYSTEM_NAME=Darwin -DCMAKE_FIND_ROOT_PATH=/root/osxcross/target/macports/pkgs/opt/local/
 RUN make
 RUN make install DESTDIR=install/
 RUN cp install/usr/local/include/* /root/osxcross/target/macports/pkgs/opt/local/include
 
 WORKDIR /root/faudio/build32
-RUN env SDL2_DIR=/root/osxcross/target/macports/pkgs/opt/local/lib/cmake/SDL2 env CFLAGS="-O3 -msse2 -target i386-apple-darwin15 -mmacosx-version-min=10.8 -B/root/osxcross/target/bin/ -isysroot/root/osxcross/target/SDK/MacOSX10.11.sdk/ -F/root/osxcross/target/macports/pkgs/opt/local/Library/Frameworks/" cmake /root/faudio/FAudio -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang -DBUILD_CPP=OFF -DCMAKE_OSX_SYSROOT=/root/osxcross/target/SDK/MacOSX10.11.sdk  -DCMAKE_SYSTEM_NAME=Darwin -DCMAKE_FIND_ROOT_PATH=/root/osxcross/target/macports/pkgs/opt/local/
+RUN env SDL2_DIR=/root/osxcross/target/macports/pkgs/opt/local/lib/cmake/SDL2 env CFLAGS="-O3 -msse2 -target i386-apple-darwin15 -mmacosx-version-min=10.8 -B/root/osxcross/target/bin/ -isysroot/root/osxcross/target/SDK/MacOSX$FRAMEWORK.sdk/ -F/root/osxcross/target/macports/pkgs/opt/local/Library/Frameworks/" cmake /root/faudio/FAudio -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang -DBUILD_CPP=OFF -DCMAKE_OSX_SYSROOT=/root/osxcross/target/SDK/MacOSX$FRAMEWORK.sdk  -DCMAKE_SYSTEM_NAME=Darwin -DCMAKE_FIND_ROOT_PATH=/root/osxcross/target/macports/pkgs/opt/local/
 RUN make
 WORKDIR /root/faudio/build
-RUN x86_64-apple-darwin15-lipo ../build32/libFAudio.0.19.05.dylib ../build64/libFAudio.0.19.05.dylib -output libFAudio.0.19.05.dylib -create
-RUN ln -s libFAudio.0.19.05.dylib libFAudio.dylib
-RUN ln -s libFAudio.0.19.05.dylib libFAudio.0.dylib
+RUN x86_64-apple-darwin15-lipo ../build32/libFAudio.0.$FAUDIO.dylib ../build64/libFAudio.0.$FAUDIO.dylib -output libFAudio.0.$FAUDIO.dylib -create
+RUN ln -s libFAudio.0.$FAUDIO.dylib libFAudio.dylib
+RUN ln -s libFAudio.0.$FAUDIO.dylib libFAudio.0.dylib
 RUN cp -d *.dylib /root/osxcross/target/macports/pkgs/opt/local/lib
 RUN rm "/root/osxcross/target/bin/ld"
 
 ## Removing preinstalled wine libs to prevent conflict
 RUN rm /root/osxcross/target/macports/pkgs/opt/local/lib/libwine.*
 RUN rm -r /root/osxcross/target/macports/pkgs/opt/local/lib/wine
-
+RUN rm -r /root/osxcross/target/macports/pkgs/opt/local/include/wine/

--- a/environments/linux-x86-wine_osxcross_hangover
+++ b/environments/linux-x86-wine_osxcross_hangover
@@ -11,7 +11,7 @@ RUN apt-get -y install git llvm clang wget
 RUN cd /root
 RUN git clone https://github.com/tpoechtrager/osxcross /root/osxcross
 
-COPY darwin/SDK/MacOSX10.8.sdk.tar.xz /root/osxcross/tarballs/
+COPY darwin/SDK/MacOSX10.11.sdk.tar.xz /root/osxcross/tarballs/
 
 RUN cd /root/osxcross && UNATTENDED=1 ./build.sh
 
@@ -21,8 +21,8 @@ ENV MACOSX_DEPLOYMENT_TARGET="10.8"
 RUN mkdir -p /root/osxcross/target/macports
 RUN printf "packages.macports.org" > /root/osxcross/target/macports/MIRROR
 
-RUN osxcross-macports -32 fakeinstall -v pulseaudio
-RUN osxcross-macports -32 install -v wine-devel
-RUN osxcross-macports -32 install gnutls-dev
+RUN osxcross-macports -64 fakeinstall -v pulseaudio
+RUN osxcross-macports -64 install -v wine-devel
+RUN osxcross-macports -64 install gnutls-dev
 
 RUN apt-get -y install gcc-mingw-w64-i686 gcc-mingw-w64-x86-64

--- a/environments/ms_hook_prologue/install_clang_ms_hook_prologue_support.sh
+++ b/environments/ms_hook_prologue/install_clang_ms_hook_prologue_support.sh
@@ -2,7 +2,7 @@
 # This script is adapted from wine-staging work
 # It compiles a compiler that support ms_hook_prologue attribute
 
-mkdir -p "/root/clang_ms_hook_prologue/"
+# mkdir -p "/root/clang_ms_hook_prologue/"
 cd "/root/clang_ms_hook_prologue/"
 apt-get -y install devscripts wget
 
@@ -37,4 +37,4 @@ cd llvm-toolchain-3.8-3.8.1
 cat ../*.patch | patch -p1
 mk-build-deps -i -r -t "apt-get -y" debian/control
 DEB_BUILD_OPTIONS=nocheck debuild -us -uc -b -j3
-exit 2
+exit 0


### PR DESCRIPTION
Removed gnuTLS support and additional changes to make maintenance simpler, by using Variables and downloading to fixed git releases.


Not in this pull-request;
We only need two Darwin builds at most, could even get away with using a single builder for all our needs the updated mac64 Environment works great for building regular wine versions.