### PR TITLE
Darwin - mingw support

### DIFF
--- a/builders/scripts/builder_darwin_amd64_wine
+++ b/builders/scripts/builder_darwin_amd64_wine
@@ -8,6 +8,8 @@ cd "/root/wine-tools"
 
 echo "[STAGE 2/11] Make tools"
 make __tooldeps__ -j 4 || exit 3
+## Make a copy before adding the wrapper to add -m32
+cp -a "/root/wine-tools" "/root/wine-tools64" || exit 4
 cd "tools/winebuild"
 mv "winebuild" "winebuild.real"
 echo '#!/bin/bash' > winebuild
@@ -36,16 +38,16 @@ chmod +x "/root/osxcross/target/bin/x86_64-apple-darwin15-gcc"
 
 ####### Install VKD3D
 echo "[STAGE 3/11] Installing vkd3d"
-bash "/root/install_vkd3d.sh" "$VKD3D" || exit 4
+bash "/root/install_vkd3d.sh" "$VKD3D" || exit 5
 
 export C_INCLUDE_PATH="/root/osxcross/target/macports/pkgs/opt/local/include/:/root/osxcross/target/macports/pkgs/opt/local/include/libxml2/:/root/vkd3d/include/"
 export LIBRARY_PATH="/root/osxcross/target/macports/pkgs/opt/local/lib"
 
 cd "/root/wine-git/wine64-build/"
 echo "[STAGE 4/11] Configure 64 bits"
-../configure --enable-win64 --host x86_64-apple-darwin15 --prefix="/" --with-wine-tools="/root/wine-tools" LFFLAGS=" -Wl,-rpath,/opt/x11/lib -L/root/osxcross/target/macports/pkgs/opt/local/lib -F/root/osxcross/target/macports/pkgs/opt/local/Library/Frameworks" || exit 5
+../configure --enable-win64 --host x86_64-apple-darwin15 --prefix="/" --with-wine-tools="/root/wine-tools64" LFFLAGS=" -Wl,-rpath,/opt/x11/lib -L/root/osxcross/target/macports/pkgs/opt/local/lib -F/root/osxcross/target/macports/pkgs/opt/local/Library/Frameworks" || exit 6
 echo "[STAGE 5/11] Make 64 bits"
-make -j 4 || exit 6
+make -j 4 || exit 7
 
 #### 32bits
 export CC="clang-7 -O3 -target i386-apple-darwin15 -mlinker-version=0.0 -mmacosx-version-min=10.8 -B/root/osxcross/target/bin/ -isysroot/root/osxcross/target/SDK/MacOSX$FRAMEWORK.sdk/ -F/root/osxcross/target/macports/pkgs/opt/local/Library/Frameworks"
@@ -55,10 +57,10 @@ chmod +x "/root/osxcross/target/bin/i386-apple-darwin15-gcc"
 
 cd "/root/wine-git/wine32-build/"
 echo "[STAGE 6/11] Configure 32 bits"
-../configure --with-wine64=/root/wine-git/wine64-build --host i386-apple-darwin15 --prefix="/" --with-wine-tools="/root/wine-tools" LFFLAGS=" -Wl,-rpath,/opt/x11/lib -L/root/osxcross/target/macports/pkgs/opt/local/lib" || exit 7
+../configure --with-wine64=/root/wine-git/wine64-build --host i386-apple-darwin15 --prefix="/" --with-wine-tools="/root/wine-tools" LFFLAGS=" -Wl,-rpath,/opt/x11/lib -L/root/osxcross/target/macports/pkgs/opt/local/lib" || exit 8
 
 echo "[STAGE 7/11] Make 32 bits"
-make -j 4 || exit 8
+make -j 4 || exit 9
 
 echo "[STAGE 8/11] Make install 64 bits"
 cd "/root/wine-git/wine64-build/"

--- a/builders/scripts/builder_darwin_mac64_wine
+++ b/builders/scripts/builder_darwin_mac64_wine
@@ -8,6 +8,8 @@ cd "/root/wine-tools"
 
 echo "[STAGE 2/11] Make tools"
 make __tooldeps__ -j 4 || exit 3
+## Make a copy before adding the wrapper to add -m32
+cp -a "/root/wine-tools" "/root/wine-tools64" || exit 4
 cd "tools/winebuild"
 mv "winebuild" "winebuild.real"
 echo '#!/bin/bash' > winebuild
@@ -28,10 +30,6 @@ ln -s "/root/osxcross/target/bin/x86_64-apple-darwin15-ar" "/root/osxcross/targe
 ln -s "/root/osxcross/target/bin/x86_64-apple-darwin15-as" "/root/osxcross/target/bin/as"
 ln -s "/root/osxcross/target/bin/x86_64-apple-darwin15-install_name_tool" "/root/osxcross/target/bin/install_name_tool"
 
-#### Wine
-export C_INCLUDE_PATH="/root/osxcross/target/macports/pkgs/opt/local/include/:/root/osxcross/target/macports/pkgs/opt/local/include/libxml2/:/root/vkd3d/include/"
-export LIBRARY_PATH="/root/osxcross/target/macports/pkgs/opt/local/lib"
-
 #### 64bits
 export CC="clang-7 -O3 -target x86_64-apple-darwin15 -mlinker-version=0.0 -mmacosx-version-min=10.8 -B/root/osxcross/target/bin/ -isysroot/root/osxcross/target/SDK/MacOSX$FRAMEWORK.sdk/  -F/root/osxcross/target/macports/pkgs/opt/local/Library/Frameworks"
 ## This hack will allow winegcc to use the right compiler
@@ -47,7 +45,7 @@ export LIBRARY_PATH="/root/osxcross/target/macports/pkgs/opt/local/lib"
 
 cd "/root/wine-git/wine64-build/"
 echo "[STAGE 4/11] Configure 64 bits"
-../configure --enable-win64 --host x86_64-apple-darwin15 --prefix="/" --with-wine-tools="/root/wine-tools" LFFLAGS=" -Wl,-rpath,/opt/x11/lib -L/root/osxcross/target/macports/pkgs/opt/local/lib -F/root/osxcross/target/macports/pkgs/opt/local/Library/Frameworks" || exit 5
+../configure --enable-win64 --host x86_64-apple-darwin15 --prefix="/" --with-wine-tools="/root/wine-tools64" LFFLAGS=" -Wl,-rpath,/opt/x11/lib -L/root/osxcross/target/macports/pkgs/opt/local/lib -F/root/osxcross/target/macports/pkgs/opt/local/Library/Frameworks" || exit 5
 echo "[STAGE 5/11] Make 64 bits"
 make -j 4 || exit 6
 

--- a/environments/darwin/install_vkd3d.sh
+++ b/environments/darwin/install_vkd3d.sh
@@ -6,7 +6,7 @@ git checkout -f "$@"
 
 export C_INCLUDE_PATH="/root/osxcross/target/macports/pkgs/opt/local/include/:/root/osxcross/target/macports/pkgs/opt/local/include/libxml2/:/root/vulkansdk-macos-${MOLTENVK}/macOS/include/:/root/SPIRV-Headers/include/:/root/SPIRV-Headers/include/spirv/"
 export LIBRARY_PATH="/root/osxcross/target/macports/pkgs/opt/local/lib:/root/vulkansdk-macos-${MOLTENVK}/macOS/lib/"
-export PATH="/root/wine-tools/tools/widl/:$PATH"
+export PATH="/root/wine-tools64/tools/widl/:$PATH"
 
 ./autogen.sh || exit 1
 ./configure --host x86_64-apple-darwin15 --prefix="/" LFFLAGS=" -Wl,-rpath,/opt/x11/lib -L/root/osxcross/target/macports/pkgs/opt/local/lib -F/root/osxcross/target/macports/pkgs/opt/local/Library/Frameworks" || exit 2

--- a/environments/linux-amd64-wine_osxcross
+++ b/environments/linux-amd64-wine_osxcross
@@ -154,3 +154,5 @@ RUN rm "/root/osxcross/target/bin/ld"
 RUN rm /root/osxcross/target/macports/pkgs/opt/local/lib/libwine.*
 RUN rm -r /root/osxcross/target/macports/pkgs/opt/local/lib/wine
 RUN rm -r /root/osxcross/target/macports/pkgs/opt/local/include/wine/
+
+RUN apt-get -y install gcc-mingw-w64-i686 gcc-mingw-w64-x86-64


### PR DESCRIPTION
These changes are currently required to compile Wine-4.9 correctly.

Wine-4.8 when compiled with mingw wants to use X11 instead of macDriver.