### PR TITLE
Fix missing libncurses and libXext

### DIFF
--- a/builders/scripts/builder_linux_amd64_runtime
+++ b/builders/scripts/builder_linux_amd64_runtime
@@ -100,6 +100,9 @@ cp -d libpulse*.so* "/root/runtime/lib64/"
 cp -d libFLAC*.so* "/root/runtime/lib64/"
 cp -d libsasl2*.so* "/root/runtime/lib64/"
 #cp -d libheimbase*.so*  "/root/runtime/lib64/" Fails currently
+cp -d libXext*.so* "/root/runtime/lib64/"
 
+cd "/lib/x86_64-linux-gnu/"
+cp -d libncurses*.so* "/root/runtime/lib64/"
 
 echo "[END]"

--- a/builders/scripts/builder_linux_x86_runtime
+++ b/builders/scripts/builder_linux_x86_runtime
@@ -100,6 +100,10 @@ cp -d libpulse*.so* "/root/runtime/lib/"
 cp -d libFLAC*.so* "/root/runtime/lib/"
 cp -d libsasl2*.so* "/root/runtime/lib/"
 #cp -d libheimbase*.so*  "/root/runtime/lib/" Fails currently
+cp -d libXext*.so* "/root/runtime/lib/"
+
+cd "/lib/i386-linux-gnu/"
+cp -d libncurses*.so* "/root/runtime/lib/"
 
 
 echo "[END]"


### PR DESCRIPTION
@qparis Could you update the runtimes accordingly ?

How can we ensure the user will install freetype 64 bits and 32 bits (since the one from the runtime makes wine crash) ?