### PR TITLE
Update runtime geneneration for linux

### DIFF
--- a/builders/scripts/builder_linux_amd64_runtime
+++ b/builders/scripts/builder_linux_amd64_runtime
@@ -8,7 +8,7 @@ cp -d libpangocairo*.so* "/root/runtime/lib64/"
 cp -d libxcb-sync*.so* "/root/runtime/lib64/"
 cp -d libp11-kit*.so* "/root/runtime/lib64/"
 cp -d libicuio*.so* "/root/runtime/lib64/"
-cp -d libidn*.so* "/root/runtime/lib64/"
+cp -d libidn*.so* "/root/runtime/lib64/" #See gnutls
 cp -d libtheoraenc*.so* "/root/runtime/lib64/"
 cp -d libgnutl*.so* "/root/runtime/lib64/"
 cp -d libgstfft*.so* "/root/runtime/lib64/"
@@ -19,16 +19,16 @@ cp -d libgsttag*.so* "/root/runtime/lib64/"
 cp -d libgstallocators*.so* "/root/runtime/lib64/"
 cp -d libgstcheck*.so* "/root/runtime/lib64/"
 cp -d libpangoxft*.so* "/root/runtime/lib64/"
-#cp -d libfreetype*.so* "/root/runtime/lib64/"
+#cp -d libfreetype*.so* "/root/runtime/lib64/" Crash wine, added in dependencies
 cp -d libgstreamer*.so* "/root/runtime/lib64/"
 cp -d libicui18n*.so* "/root/runtime/lib64/"
 cp -d libpangoft2*.so* "/root/runtime/lib64/"
 cp -d libgstcontroller*.so* "/root/runtime/lib64/"
 cp -d libcairo-script-interpreter*.so* "/root/runtime/lib64/"
 cp -d libicuuc*.so* "/root/runtime/lib64/"
-#cp -d libfontconfig*.so* "/root/runtime/lib64/"
+#cp -d libfontconfig*.so* "/root/runtime/lib64/" cannot find the right config file
 cp /usr/local/lib/libFAudio*.so* "/root/runtime/lib64/"
-cp -d libgnutls*.so* "/root/runtime/lib64/"
+cp -d libgnutls*.so* "/root/runtime/lib64/" #Does not work but should
 cp -d libpango*.so* "/root/runtime/lib64/"
 cp -d libgstbase*.so* "/root/runtime/lib64/"
 cp -d libltdl*.so* "/root/runtime/lib64/"
@@ -86,7 +86,7 @@ cp -d libgstbase*.so* "/root/runtime/lib64/"
 cp -d liblcms2*.so* "/root/runtime/lib64/"
 cp -d libopus*.so* "/root/runtime/lib64/"
 cp -d libpango*.so* "/root/runtime/lib64/"
-cp -d libncurses*.so* "/root/runtime/lib64/"
+#cp -d libncurses*.so* "/root/runtime/lib64/" Does not work, added in dependencies
 cp -d libjpeg*.so* "/root/runtime/lib64/"
 cp -d libsqlite3*.so* "/root/runtime/lib64/"
 cp -d libavcodec*.so* "/root/runtime/lib64/"
@@ -100,10 +100,13 @@ cp -d libpulse*.so* "/root/runtime/lib64/"
 cp -d libFLAC*.so* "/root/runtime/lib64/"
 cp -d libsasl2*.so* "/root/runtime/lib64/"
 #cp -d libheimbase*.so*  "/root/runtime/lib64/" Fails currently
-cp -d libXext*.so* "/root/runtime/lib64/"
+cp -d libX*.so* "/root/runtime/lib64/"
+cp -d libxcb*.so* "/root/runtime/lib64"
+cp -d libstdc++*.so* "/root/runtime/lib64"
+#cp -d libbsd*.so* "/root/runtime/lib" Not found, added in dependencies
 
 cd "/lib/x86_64-linux-gnu/"
-cp -d libncurses*.so* "/root/runtime/lib64/"
-cp -d libidn*.so* "/root/runtime/lib64/"
+#cp -d libncurses*.so* "/root/runtime/lib64/" Does not work, added in dependencies
+cp -d libidn*.so* "/root/runtime/lib64/" #See gnutls
 
 echo "[END]"

--- a/builders/scripts/builder_linux_x86_runtime
+++ b/builders/scripts/builder_linux_x86_runtime
@@ -8,7 +8,7 @@ cp -d libpangocairo*.so* "/root/runtime/lib/"
 cp -d libxcb-sync*.so* "/root/runtime/lib/"
 cp -d libp11-kit*.so* "/root/runtime/lib/"
 cp -d libicuio*.so* "/root/runtime/lib/"
-cp -d libidn*.so* "/root/runtime/lib/"
+cp -d libidn*.so* "/root/runtime/lib/" #See gnutls
 cp -d libtheoraenc*.so* "/root/runtime/lib/"
 cp -d libgnutl*.so* "/root/runtime/lib/"
 cp -d libgstfft*.so* "/root/runtime/lib/"
@@ -19,7 +19,7 @@ cp -d libgsttag*.so* "/root/runtime/lib/"
 cp -d libgstallocators*.so* "/root/runtime/lib/"
 cp -d libgstcheck*.so* "/root/runtime/lib/"
 cp -d libpangoxft*.so* "/root/runtime/lib/"
-# cp -d libfreetype*.so* "/root/runtime/lib/"
+# cp -d libfreetype*.so* "/root/runtime/lib/" Crash wine, added in dependencies
 cp -d libgstreamer*.so* "/root/runtime/lib/"
 cp -d libicui18n*.so* "/root/runtime/lib/"
 cp -d libpangoft2*.so* "/root/runtime/lib/"
@@ -28,7 +28,7 @@ cp -d libcairo-script-interpreter*.so* "/root/runtime/lib/"
 cp -d libicuuc*.so* "/root/runtime/lib/"
 # cp -d libfontconfig*.so* "/root/runtime/lib/" cannot find the right config file
 cp /usr/local/lib/libFAudio*.so* "/root/runtime/lib/"
-cp -d libgnutls*.so* "/root/runtime/lib/"
+cp -d libgnutls*.so* "/root/runtime/lib/" #Does not work but should
 cp -d libpango*.so* "/root/runtime/lib/"
 cp -d libgstbase*.so* "/root/runtime/lib/"
 cp -d libltdl*.so* "/root/runtime/lib/"
@@ -86,7 +86,7 @@ cp -d libgstbase*.so* "/root/runtime/lib/"
 cp -d liblcms2*.so* "/root/runtime/lib/"
 cp -d libopus*.so* "/root/runtime/lib/"
 cp -d libpango*.so* "/root/runtime/lib/"
-cp -d libncurses*.so* "/root/runtime/lib/"
+#cp -d libncurses*.so* "/root/runtime/lib/" Does not work, added in dependencies
 cp -d libjpeg*.so* "/root/runtime/lib/"
 cp -d libsqlite3*.so* "/root/runtime/lib/"
 cp -d libavcodec*.so* "/root/runtime/lib/"
@@ -100,11 +100,13 @@ cp -d libpulse*.so* "/root/runtime/lib/"
 cp -d libFLAC*.so* "/root/runtime/lib/"
 cp -d libsasl2*.so* "/root/runtime/lib/"
 #cp -d libheimbase*.so*  "/root/runtime/lib/" Fails currently
-cp -d libXext*.so* "/root/runtime/lib/"
+cp -d libX*.so* "/root/runtime/lib/"
+cp -d libxcb*.so* "/root/runtime/lib"
+cp -d libstdc++*.so* "/root/runtime/lib"
+#cp -d libbsd*.so* "/root/runtime/lib" Not found, added in dependencies
 
 cd "/lib/i386-linux-gnu/"
-cp -d libncurses*.so* "/root/runtime/lib/"
-cp -d libidn*.so* "/root/runtime/lib/"
-
+#cp -d libncurses*.so* "/root/runtime/lib/" Does not work, added in dependencies
+cp -d libidn*.so* "/root/runtime/lib/" #See gnutls
 
 echo "[END]"

--- a/environments/linux-x86-wine
+++ b/environments/linux-x86-wine
@@ -7,7 +7,7 @@ RUN echo 'deb-src http://deb.debian.org/debian stretch-updates main' >> /etc/apt
 RUN apt-get update
 RUN apt-get -y build-dep wine
 RUN apt-get -y install libkrb5-dev opencl-dev libpcap-dev libsane-dev libv4l-dev libgphoto2-dev libtiff-dev libpulse-dev libgstreamer1.0-dev libudev-dev libcapi20-dev libgstreamer-plugins-base1.0-dev
-RUN apt-get -y install git libdbus-1-dev fcitx-libs-dev libsamplerate0-dev libibus libibus-1.0-dev
+RUN apt-get -y install git libdbus-1-dev fcitx-libs-dev libsamplerate0-dev libibus-1.0-dev
 RUN apt-get -y install mingw-w64
 
 # Wine Staging


### PR DESCRIPTION
For someone that does not have any i386 package, he would be missing a lot of libX* lib.

Moreover, libgnutls is not found by wine despite being in the runtime :/.

@qparis please generate new .json and .tar.gz.