### PR TITLE
Fix undetected libgnutls (missing libgmp), libncurses and others

### DIFF
--- a/builders/scripts/builder_linux_amd64_runtime
+++ b/builders/scripts/builder_linux_amd64_runtime
@@ -104,6 +104,7 @@ cp -d libX*.so* "/root/runtime/lib64/"
 cp -d libxcb*.so* "/root/runtime/lib64"
 cp -d libstdc++*.so* "/root/runtime/lib64"
 #cp -d libbsd*.so* "/root/runtime/lib" Not found, added in dependencies
+cp -d libgmp*.so* "/root/runtime/lib64"
 
 cd "/lib/x86_64-linux-gnu/"
 #cp -d libncurses*.so* "/root/runtime/lib64/" Does not work, added in dependencies

--- a/builders/scripts/builder_linux_amd64_runtime
+++ b/builders/scripts/builder_linux_amd64_runtime
@@ -8,7 +8,6 @@ cp -d libpangocairo*.so* "/root/runtime/lib64/"
 cp -d libxcb-sync*.so* "/root/runtime/lib64/"
 cp -d libp11-kit*.so* "/root/runtime/lib64/"
 cp -d libicuio*.so* "/root/runtime/lib64/"
-#cp -d libidn*.so* "/root/runtime/lib64/" See gnutls
 cp -d libtheoraenc*.so* "/root/runtime/lib64/"
 cp -d libgnutl*.so* "/root/runtime/lib64/"
 cp -d libgstfft*.so* "/root/runtime/lib64/"
@@ -19,7 +18,7 @@ cp -d libgsttag*.so* "/root/runtime/lib64/"
 cp -d libgstallocators*.so* "/root/runtime/lib64/"
 cp -d libgstcheck*.so* "/root/runtime/lib64/"
 cp -d libpangoxft*.so* "/root/runtime/lib64/"
-# cp -d libfreetype*.so* "/root/runtime/lib64/" Crash wine, added in dependencies
+cp -d libfreetype*.so* "/root/runtime/lib64/"
 cp -d libgstreamer*.so* "/root/runtime/lib64/"
 cp -d libicui18n*.so* "/root/runtime/lib64/"
 cp -d libpangoft2*.so* "/root/runtime/lib64/"
@@ -28,7 +27,7 @@ cp -d libcairo-script-interpreter*.so* "/root/runtime/lib64/"
 cp -d libicuuc*.so* "/root/runtime/lib64/"
 # cp -d libfontconfig*.so* "/root/runtime/lib64/" cannot find the right config file
 cp /usr/local/lib/libFAudio*.so* "/root/runtime/lib64/"
-cp -d libgnutls*.so* "/root/runtime/lib64/" #Does not work but should
+cp -d libgnutls*.so* "/root/runtime/lib64/"
 cp -d libpango*.so* "/root/runtime/lib64/"
 cp -d libgstbase*.so* "/root/runtime/lib64/"
 cp -d libltdl*.so* "/root/runtime/lib64/"
@@ -108,9 +107,11 @@ cp -d libpanel*.so.* "/root/runtime/lib64/"
 cp -d libtic*.so.* "/root/runtime/lib64/"
 
 cd "/lib/x86_64-linux-gnu/"
-cp -d libncurses*.so* "/root/runtime/lib64/" #Does not work, added in dependencies
+cp -d libncurses*.so* "/root/runtime/lib64/"
 cp -d libtinfo*.so* "/root/runtime/lib64/"
-cp -d libidn*.so* "/root/runtime/lib64/" #See gnutls
-cp -d libbsd*.so* "/root/runtime/lib64/"
+cp -d libidn*.so* "/root/runtime/lib64/"
+cp -d libbsd*.so* "/root/runtime/lib64/" 
+cp -d libz*.so* "/root/runtime/lib64/" 
+cp -d libudev*.so* "/root/runtime/lib64/" 
 
 echo "[END]"

--- a/builders/scripts/builder_linux_amd64_runtime
+++ b/builders/scripts/builder_linux_amd64_runtime
@@ -8,7 +8,7 @@ cp -d libpangocairo*.so* "/root/runtime/lib64/"
 cp -d libxcb-sync*.so* "/root/runtime/lib64/"
 cp -d libp11-kit*.so* "/root/runtime/lib64/"
 cp -d libicuio*.so* "/root/runtime/lib64/"
-cp -d libidn*.so* "/root/runtime/lib64/" #See gnutls
+#cp -d libidn*.so* "/root/runtime/lib64/" See gnutls
 cp -d libtheoraenc*.so* "/root/runtime/lib64/"
 cp -d libgnutl*.so* "/root/runtime/lib64/"
 cp -d libgstfft*.so* "/root/runtime/lib64/"
@@ -19,14 +19,14 @@ cp -d libgsttag*.so* "/root/runtime/lib64/"
 cp -d libgstallocators*.so* "/root/runtime/lib64/"
 cp -d libgstcheck*.so* "/root/runtime/lib64/"
 cp -d libpangoxft*.so* "/root/runtime/lib64/"
-#cp -d libfreetype*.so* "/root/runtime/lib64/" Crash wine, added in dependencies
+# cp -d libfreetype*.so* "/root/runtime/lib64/" Crash wine, added in dependencies
 cp -d libgstreamer*.so* "/root/runtime/lib64/"
 cp -d libicui18n*.so* "/root/runtime/lib64/"
 cp -d libpangoft2*.so* "/root/runtime/lib64/"
 cp -d libgstcontroller*.so* "/root/runtime/lib64/"
 cp -d libcairo-script-interpreter*.so* "/root/runtime/lib64/"
 cp -d libicuuc*.so* "/root/runtime/lib64/"
-#cp -d libfontconfig*.so* "/root/runtime/lib64/" cannot find the right config file
+# cp -d libfontconfig*.so* "/root/runtime/lib64/" cannot find the right config file
 cp /usr/local/lib/libFAudio*.so* "/root/runtime/lib64/"
 cp -d libgnutls*.so* "/root/runtime/lib64/" #Does not work but should
 cp -d libpango*.so* "/root/runtime/lib64/"
@@ -86,7 +86,6 @@ cp -d libgstbase*.so* "/root/runtime/lib64/"
 cp -d liblcms2*.so* "/root/runtime/lib64/"
 cp -d libopus*.so* "/root/runtime/lib64/"
 cp -d libpango*.so* "/root/runtime/lib64/"
-#cp -d libncurses*.so* "/root/runtime/lib64/" Does not work, added in dependencies
 cp -d libjpeg*.so* "/root/runtime/lib64/"
 cp -d libsqlite3*.so* "/root/runtime/lib64/"
 cp -d libavcodec*.so* "/root/runtime/lib64/"
@@ -101,13 +100,17 @@ cp -d libFLAC*.so* "/root/runtime/lib64/"
 cp -d libsasl2*.so* "/root/runtime/lib64/"
 #cp -d libheimbase*.so*  "/root/runtime/lib64/" Fails currently
 cp -d libX*.so* "/root/runtime/lib64/"
-cp -d libxcb*.so* "/root/runtime/lib64"
-cp -d libstdc++*.so* "/root/runtime/lib64"
-#cp -d libbsd*.so* "/root/runtime/lib" Not found, added in dependencies
-cp -d libgmp*.so* "/root/runtime/lib64"
+cp -d libxcb*.so* "/root/runtime/lib64/"
+cp -d libstdc++*.so* "/root/runtime/lib64/"
+cp -d libgmp*.so* "/root/runtime/lib64/"
+cp -d libmenu*.so.* "/root/runtime/lib64/"
+cp -d libpanel*.so.* "/root/runtime/lib64/"
+cp -d libtic*.so.* "/root/runtime/lib64/"
 
 cd "/lib/x86_64-linux-gnu/"
-#cp -d libncurses*.so* "/root/runtime/lib64/" Does not work, added in dependencies
+cp -d libncurses*.so* "/root/runtime/lib64/" #Does not work, added in dependencies
+cp -d libtinfo*.so* "/root/runtime/lib64/"
 cp -d libidn*.so* "/root/runtime/lib64/" #See gnutls
+cp -d libbsd*.so* "/root/runtime/lib64/"
 
 echo "[END]"

--- a/builders/scripts/builder_linux_x86_runtime
+++ b/builders/scripts/builder_linux_x86_runtime
@@ -104,6 +104,7 @@ cp -d libX*.so* "/root/runtime/lib/"
 cp -d libxcb*.so* "/root/runtime/lib"
 cp -d libstdc++*.so* "/root/runtime/lib"
 #cp -d libbsd*.so* "/root/runtime/lib" Not found, added in dependencies
+cp -d libgmp*.so* "/root/runtime/lib"
 
 cd "/lib/i386-linux-gnu/"
 #cp -d libncurses*.so* "/root/runtime/lib/" Does not work, added in dependencies

--- a/builders/scripts/builder_linux_x86_runtime
+++ b/builders/scripts/builder_linux_x86_runtime
@@ -8,7 +8,7 @@ cp -d libpangocairo*.so* "/root/runtime/lib/"
 cp -d libxcb-sync*.so* "/root/runtime/lib/"
 cp -d libp11-kit*.so* "/root/runtime/lib/"
 cp -d libicuio*.so* "/root/runtime/lib/"
-cp -d libidn*.so* "/root/runtime/lib/" #See gnutls
+#cp -d libidn*.so* "/root/runtime/lib/" See gnutls
 cp -d libtheoraenc*.so* "/root/runtime/lib/"
 cp -d libgnutl*.so* "/root/runtime/lib/"
 cp -d libgstfft*.so* "/root/runtime/lib/"
@@ -86,7 +86,6 @@ cp -d libgstbase*.so* "/root/runtime/lib/"
 cp -d liblcms2*.so* "/root/runtime/lib/"
 cp -d libopus*.so* "/root/runtime/lib/"
 cp -d libpango*.so* "/root/runtime/lib/"
-#cp -d libncurses*.so* "/root/runtime/lib/" Does not work, added in dependencies
 cp -d libjpeg*.so* "/root/runtime/lib/"
 cp -d libsqlite3*.so* "/root/runtime/lib/"
 cp -d libavcodec*.so* "/root/runtime/lib/"
@@ -103,11 +102,15 @@ cp -d libsasl2*.so* "/root/runtime/lib/"
 cp -d libX*.so* "/root/runtime/lib/"
 cp -d libxcb*.so* "/root/runtime/lib"
 cp -d libstdc++*.so* "/root/runtime/lib"
-#cp -d libbsd*.so* "/root/runtime/lib" Not found, added in dependencies
 cp -d libgmp*.so* "/root/runtime/lib"
+cp -d libmenu*.so.* "/root/runtime/lib"
+cp -d libpanel*.so.* "/root/runtime/lib"
+cp -d libtic*.so.* "/root/runtime/lib"
 
 cd "/lib/i386-linux-gnu/"
-#cp -d libncurses*.so* "/root/runtime/lib/" Does not work, added in dependencies
+cp -d libncurses*.so* "/root/runtime/lib/" #Does not work, added in dependencies
+cp -d libtinfo*.so* "/root/runtime/lib/"
 cp -d libidn*.so* "/root/runtime/lib/" #See gnutls
+cp -d libbsd*.so* "/root/runtime/lib"
 
 echo "[END]"

--- a/builders/scripts/builder_linux_x86_runtime
+++ b/builders/scripts/builder_linux_x86_runtime
@@ -8,7 +8,6 @@ cp -d libpangocairo*.so* "/root/runtime/lib/"
 cp -d libxcb-sync*.so* "/root/runtime/lib/"
 cp -d libp11-kit*.so* "/root/runtime/lib/"
 cp -d libicuio*.so* "/root/runtime/lib/"
-#cp -d libidn*.so* "/root/runtime/lib/" See gnutls
 cp -d libtheoraenc*.so* "/root/runtime/lib/"
 cp -d libgnutl*.so* "/root/runtime/lib/"
 cp -d libgstfft*.so* "/root/runtime/lib/"
@@ -19,7 +18,7 @@ cp -d libgsttag*.so* "/root/runtime/lib/"
 cp -d libgstallocators*.so* "/root/runtime/lib/"
 cp -d libgstcheck*.so* "/root/runtime/lib/"
 cp -d libpangoxft*.so* "/root/runtime/lib/"
-# cp -d libfreetype*.so* "/root/runtime/lib/" Crash wine, added in dependencies
+cp -d libfreetype*.so* "/root/runtime/lib/"
 cp -d libgstreamer*.so* "/root/runtime/lib/"
 cp -d libicui18n*.so* "/root/runtime/lib/"
 cp -d libpangoft2*.so* "/root/runtime/lib/"
@@ -28,7 +27,7 @@ cp -d libcairo-script-interpreter*.so* "/root/runtime/lib/"
 cp -d libicuuc*.so* "/root/runtime/lib/"
 # cp -d libfontconfig*.so* "/root/runtime/lib/" cannot find the right config file
 cp /usr/local/lib/libFAudio*.so* "/root/runtime/lib/"
-cp -d libgnutls*.so* "/root/runtime/lib/" #Does not work but should
+cp -d libgnutls*.so* "/root/runtime/lib/"
 cp -d libpango*.so* "/root/runtime/lib/"
 cp -d libgstbase*.so* "/root/runtime/lib/"
 cp -d libltdl*.so* "/root/runtime/lib/"
@@ -108,9 +107,12 @@ cp -d libpanel*.so.* "/root/runtime/lib"
 cp -d libtic*.so.* "/root/runtime/lib"
 
 cd "/lib/i386-linux-gnu/"
-cp -d libncurses*.so* "/root/runtime/lib/" #Does not work, added in dependencies
+cp -d libncurses*.so* "/root/runtime/lib/"
 cp -d libtinfo*.so* "/root/runtime/lib/"
-cp -d libidn*.so* "/root/runtime/lib/" #See gnutls
+cp -d libidn*.so* "/root/runtime/lib/"
 cp -d libbsd*.so* "/root/runtime/lib"
+cp -d libz*.so* "/root/runtime/lib"
+cp -d libudev*.so* "/root/runtime/lib"
+
 
 echo "[END]"


### PR DESCRIPTION
Fix #97.

@qparis You know what to do ;-).

EDIT: no need to have libbsd and libncurses in the .deb nox ^^.