### PR TITLE
Darwin updates required to compile Wine-4.15 and above

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Ensure that your current user belongs to the docker group. You might need to res
 
 ### OSX targeted builds
 
-You need to extract Mac OS 10.11 SDK from [XCode 7.3.1](https://download.developer.apple.com/Developer_Tools/Xcode_7.3.1/Xcode_7.3.1.dmg), compress it into a .tar.xz file and place it to darwin/SDK directory  
+You need to extract Mac OS 10.13 SDK from [XCode 9.4.1](https://download.developer.apple.com/Developer_Tools/Xcode_9.4.1/Xcode_9.4.1.xip), compress it into a .tar.xz file and place it to darwin/SDK directory  
 
 ## How to use
 

--- a/builders/scripts/builder_darwin_amd64_runtime
+++ b/builders/scripts/builder_darwin_amd64_runtime
@@ -9,18 +9,18 @@ cd "/root/wine-tools64/"
 make __tooldeps__ -j 4
 
 ## Some tools are not directly found by wine
-ln -s "/root/osxcross/target/bin/i386-apple-darwin15-ld" "/root/osxcross/target/bin/ld"
-ln -s "/root/osxcross/target/bin/i386-apple-darwin15-otool" "/root/osxcross/target/bin/otool"
-ln -s "/root/osxcross/target/bin/i386-apple-darwin15-ranlib" "/root/osxcross/target/bin/ranlib"
-ln -s "/root/osxcross/target/bin/i386-apple-darwin15-ar" "/root/osxcross/target/bin/ar"
-ln -s "/root/osxcross/target/bin/i386-apple-darwin15-as" "/root/osxcross/target/bin/as"
-ln -s "/root/osxcross/target/bin/i386-apple-darwin15-install_name_tool" "/root/osxcross/target/bin/install_name_tool"
+ln -s "/root/osxcross/target/bin/i386-apple-darwin17-ld" "/root/osxcross/target/bin/ld"
+ln -s "/root/osxcross/target/bin/i386-apple-darwin17-otool" "/root/osxcross/target/bin/otool"
+ln -s "/root/osxcross/target/bin/i386-apple-darwin17-ranlib" "/root/osxcross/target/bin/ranlib"
+ln -s "/root/osxcross/target/bin/i386-apple-darwin17-ar" "/root/osxcross/target/bin/ar"
+ln -s "/root/osxcross/target/bin/i386-apple-darwin17-as" "/root/osxcross/target/bin/as"
+ln -s "/root/osxcross/target/bin/i386-apple-darwin17-install_name_tool" "/root/osxcross/target/bin/install_name_tool"
 
 #### 64bits
-export CC="clang-7 -O3 -target x86_64-apple-darwin15 -mlinker-version=0.0 -mmacosx-version-min=10.8 -B/root/osxcross/target/bin/ -isysroot/root/osxcross/target/SDK/MacOSX$FRAMEWORK.sdk/  -F/root/osxcross/target/macports/pkgs/opt/local/Library/Frameworks"
+export CC="clang-7 -O3 -target x86_64-apple-darwin17 -mlinker-version=0.0 -mmacosx-version-min=10.8 -B/root/osxcross/target/bin/ -isysroot/root/osxcross/target/SDK/MacOSX$FRAMEWORK.sdk/  -F/root/osxcross/target/macports/pkgs/opt/local/Library/Frameworks"
 ## This hack will allow winegcc to use the right compiler
-echo '$CC "$@"' > "/root/osxcross/target/bin/x86_64-apple-darwin15-gcc"
-chmod +x "/root/osxcross/target/bin/x86_64-apple-darwin15-gcc"
+echo '$CC "$@"' > "/root/osxcross/target/bin/x86_64-apple-darwin17-gcc"
+chmod +x "/root/osxcross/target/bin/x86_64-apple-darwin17-gcc"
 
 ####### Install VKD3D
 echo "[STAGE 3/11] Installing vkd3d"
@@ -149,6 +149,10 @@ rm libxcb.1.dylib
 rm libxcb.dylib
 rm libxslt.1.dylib
 rm libxslt.dylib
+
+# remove libunwind not needed at runtime
+rm libunwind.dylib
+rm libunwind.1.dylib
 
 ## Fixing imports
 bash /root/fix_imports.sh "/root/runtime"

--- a/builders/scripts/builder_darwin_amd64_runtime
+++ b/builders/scripts/builder_darwin_amd64_runtime
@@ -2,10 +2,10 @@
 
 ####### Build Tools
 cd "/root/"
-git clone -b "wine-4.0.1" https://github.com/wine-mirror/wine
+git clone -b "wine-4.0.2" https://github.com/wine-mirror/wine
 cp -a "/root/wine" "/root/wine-tools64"
 cd "/root/wine-tools64/"
-./configure --enable-win64
+./configure --without-unwind --enable-win64
 make __tooldeps__ -j 4
 
 ## Some tools are not directly found by wine
@@ -149,10 +149,6 @@ rm libxcb.1.dylib
 rm libxcb.dylib
 rm libxslt.1.dylib
 rm libxslt.dylib
-
-# remove libunwind not needed at runtime
-rm libunwind.dylib
-rm libunwind.1.dylib
 
 ## Fixing imports
 bash /root/fix_imports.sh "/root/runtime"

--- a/builders/scripts/builder_darwin_amd64_runtime
+++ b/builders/scripts/builder_darwin_amd64_runtime
@@ -147,8 +147,6 @@ rm libxcb-xvmc.0.dylib
 rm libxcb-xvmc.dylib
 rm libxcb.1.dylib
 rm libxcb.dylib
-rm libxslt.1.dylib
-rm libxslt.dylib
 
 ## Fixing imports
 bash /root/fix_imports.sh "/root/runtime"

--- a/builders/scripts/builder_darwin_amd64_wine
+++ b/builders/scripts/builder_darwin_amd64_wine
@@ -20,21 +20,21 @@ chmod +x winebuild
 ### Environment preparation
 mkdir -p "/root/wine-git/wine64-build/"
 mkdir -p "/root/wine-git/wine32-build/"
-export FRAMEWORK="10.11"
 
 ## Some tools are not directly found by wine
-ln -s "/root/osxcross/target/bin/i386-apple-darwin15-ld" "/root/osxcross/target/bin/ld"
-ln -s "/root/osxcross/target/bin/i386-apple-darwin15-otool" "/root/osxcross/target/bin/otool"
-ln -s "/root/osxcross/target/bin/i386-apple-darwin15-ranlib" "/root/osxcross/target/bin/ranlib"
-ln -s "/root/osxcross/target/bin/i386-apple-darwin15-ar" "/root/osxcross/target/bin/ar"
-ln -s "/root/osxcross/target/bin/i386-apple-darwin15-as" "/root/osxcross/target/bin/as"
-ln -s "/root/osxcross/target/bin/i386-apple-darwin15-install_name_tool" "/root/osxcross/target/bin/install_name_tool"
+ln -s "/root/osxcross/target/bin/i386-apple-darwin17-ld" "/root/osxcross/target/bin/ld"
+ln -s "/root/osxcross/target/bin/i386-apple-darwin17-otool" "/root/osxcross/target/bin/otool"
+ln -s "/root/osxcross/target/bin/i386-apple-darwin17-ranlib" "/root/osxcross/target/bin/ranlib"
+ln -s "/root/osxcross/target/bin/i386-apple-darwin17-ar" "/root/osxcross/target/bin/ar"
+ln -s "/root/osxcross/target/bin/i386-apple-darwin17-as" "/root/osxcross/target/bin/as"
+ln -s "/root/osxcross/target/bin/i386-apple-darwin17-install_name_tool" "/root/osxcross/target/bin/install_name_tool"
 
 #### 64bits
-export CC="clang-7 -O3 -target x86_64-apple-darwin15 -mlinker-version=0.0 -mmacosx-version-min=10.8 -B/root/osxcross/target/bin/ -isysroot/root/osxcross/target/SDK/MacOSX$FRAMEWORK.sdk/  -F/root/osxcross/target/macports/pkgs/opt/local/Library/Frameworks"
+export CC="clang-7 -O3 -target x86_64-apple-darwin17 -mlinker-version=0.0 -mmacosx-version-min=10.8 -B/root/osxcross/target/bin/ -isysroot/root/osxcross/target/SDK/MacOSX$FRAMEWORK.sdk/  -F/root/osxcross/target/macports/pkgs/opt/local/Library/Frameworks -Wno-unused-command-line-argument -Wno-deprecated-declarations"
+
 ## This hack will allow winegcc to use the right compiler
-echo '$CC "$@"' > "/root/osxcross/target/bin/x86_64-apple-darwin15-gcc"
-chmod +x "/root/osxcross/target/bin/x86_64-apple-darwin15-gcc"
+echo '$CC "$@"' > "/root/osxcross/target/bin/x86_64-apple-darwin17-gcc"
+chmod +x "/root/osxcross/target/bin/x86_64-apple-darwin17-gcc"
 
 ####### Install VKD3D
 echo "[STAGE 3/11] Installing vkd3d"
@@ -45,19 +45,19 @@ export LIBRARY_PATH="/root/osxcross/target/macports/pkgs/opt/local/lib"
 
 cd "/root/wine-git/wine64-build/"
 echo "[STAGE 4/11] Configure 64 bits"
-../configure --enable-win64 --host x86_64-apple-darwin15 --prefix="/" --with-wine-tools="/root/wine-tools64" LFFLAGS=" -Wl,-rpath,/opt/x11/lib -L/root/osxcross/target/macports/pkgs/opt/local/lib -F/root/osxcross/target/macports/pkgs/opt/local/Library/Frameworks" || exit 6
+../configure --enable-win64 --host x86_64-apple-darwin17 --prefix="/" --with-wine-tools="/root/wine-tools64" LFFLAGS=" -Wl,-rpath,/opt/x11/lib -L/root/osxcross/target/macports/pkgs/opt/local/lib -F/root/osxcross/target/macports/pkgs/opt/local/Library/Frameworks" || exit 6
 echo "[STAGE 5/11] Make 64 bits"
 make -j 4 || exit 7
 
 #### 32bits
-export CC="clang-7 -O3 -target i386-apple-darwin15 -mlinker-version=0.0 -mmacosx-version-min=10.8 -B/root/osxcross/target/bin/ -isysroot/root/osxcross/target/SDK/MacOSX$FRAMEWORK.sdk/ -F/root/osxcross/target/macports/pkgs/opt/local/Library/Frameworks"
+export CC="clang-7 -O3 -target i386-apple-darwin17 -mlinker-version=0.0 -mmacosx-version-min=10.8 -B/root/osxcross/target/bin/ -isysroot/root/osxcross/target/SDK/MacOSX$FRAMEWORK.sdk/ -F/root/osxcross/target/macports/pkgs/opt/local/Library/Frameworks -Wno-unused-command-line-argument -Wno-deprecated-declarations"
 ## This hack will allow winegcc to use the right compiler
-echo '$CC "$@"' > "/root/osxcross/target/bin/i386-apple-darwin15-gcc"
-chmod +x "/root/osxcross/target/bin/i386-apple-darwin15-gcc"
+echo '$CC "$@"' > "/root/osxcross/target/bin/i386-apple-darwin17-gcc"
+chmod +x "/root/osxcross/target/bin/i386-apple-darwin17-gcc"
 
 cd "/root/wine-git/wine32-build/"
 echo "[STAGE 6/11] Configure 32 bits"
-../configure --with-wine64=/root/wine-git/wine64-build --host i386-apple-darwin15 --prefix="/" --with-wine-tools="/root/wine-tools" LFFLAGS=" -Wl,-rpath,/opt/x11/lib -L/root/osxcross/target/macports/pkgs/opt/local/lib" || exit 8
+../configure --with-wine64=/root/wine-git/wine64-build --host i386-apple-darwin17 --prefix="/" --with-wine-tools="/root/wine-tools" LFFLAGS=" -Wl,-rpath,/opt/x11/lib -L/root/osxcross/target/macports/pkgs/opt/local/lib" || exit 8
 
 echo "[STAGE 7/11] Make 32 bits"
 make -j 4 || exit 9
@@ -191,6 +191,10 @@ rm libxcb.1.dylib
 rm libxcb.dylib
 rm libxslt.1.dylib
 rm libxslt.dylib
+
+# remove libunwind not needed at runtime
+rm libunwind.dylib
+rm libunwind.1.dylib
 
 ## Fixing imports
 echo "[STAGE 11/11] Fixing imports"

--- a/builders/scripts/builder_darwin_amd64_wine
+++ b/builders/scripts/builder_darwin_amd64_wine
@@ -4,7 +4,7 @@ cp -a "/root/wine-git" "/root/wine-tools" || exit 1
 ####### Build Tools
 echo "[STAGE 1/11] Configure tools"
 cd "/root/wine-tools"
-./configure --enable-win64 || exit 2
+./configure --without-unwind --enable-win64 || exit 2
 
 echo "[STAGE 2/11] Make tools"
 make __tooldeps__ -j 4 || exit 3
@@ -45,7 +45,7 @@ export LIBRARY_PATH="/root/osxcross/target/macports/pkgs/opt/local/lib"
 
 cd "/root/wine-git/wine64-build/"
 echo "[STAGE 4/11] Configure 64 bits"
-../configure --enable-win64 --host x86_64-apple-darwin17 --prefix="/" --with-wine-tools="/root/wine-tools64" LFFLAGS=" -Wl,-rpath,/opt/x11/lib -L/root/osxcross/target/macports/pkgs/opt/local/lib -F/root/osxcross/target/macports/pkgs/opt/local/Library/Frameworks" || exit 6
+../configure --without-unwind --enable-win64 --host x86_64-apple-darwin17 --prefix="/" --with-wine-tools="/root/wine-tools64" LFFLAGS=" -Wl,-rpath,/opt/x11/lib -L/root/osxcross/target/macports/pkgs/opt/local/lib -F/root/osxcross/target/macports/pkgs/opt/local/Library/Frameworks" || exit 6
 echo "[STAGE 5/11] Make 64 bits"
 make -j 4 || exit 7
 
@@ -191,10 +191,6 @@ rm libxcb.1.dylib
 rm libxcb.dylib
 rm libxslt.1.dylib
 rm libxslt.dylib
-
-# remove libunwind not needed at runtime
-rm libunwind.dylib
-rm libunwind.1.dylib
 
 ## Fixing imports
 echo "[STAGE 11/11] Fixing imports"

--- a/builders/scripts/builder_darwin_amd64_wine
+++ b/builders/scripts/builder_darwin_amd64_wine
@@ -189,8 +189,6 @@ rm libxcb-xvmc.0.dylib
 rm libxcb-xvmc.dylib
 rm libxcb.1.dylib
 rm libxcb.dylib
-rm libxslt.1.dylib
-rm libxslt.dylib
 
 ## Fixing imports
 echo "[STAGE 11/11] Fixing imports"

--- a/builders/scripts/builder_darwin_amd64_wine_hangover
+++ b/builders/scripts/builder_darwin_amd64_wine_hangover
@@ -12,22 +12,21 @@ make __tooldeps__ -j 4
 ln -s /root/hangover/build/wine-tools /root/wine-tools64
 
 ##### Cross environment
-export FRAMEWORK="10.11"
 
 ## Some tools are not directly found by wine
-ln -s "/root/osxcross/target/bin/x86_64-apple-darwin15-ld" "/root/osxcross/target/bin/ld"
-ln -s "/root/osxcross/target/bin/x86_64-apple-darwin15-otool" "/root/osxcross/target/bin/otool"
-ln -s "/root/osxcross/target/bin/x86_64-apple-darwin15-ranlib" "/root/osxcross/target/bin/ranlib"
-ln -s "/root/osxcross/target/bin/x86_64-apple-darwin15-ar" "/root/osxcross/target/bin/ar"
-ln -s "/root/osxcross/target/bin/x86_64-apple-darwin15-as" "/root/osxcross/target/bin/as"
-ln -s "/root/osxcross/target/bin/x86_64-apple-darwin15-install_name_tool" "/root/osxcross/target/bin/install_name_tool"
+ln -s "/root/osxcross/target/bin/x86_64-apple-darwin17-ld" "/root/osxcross/target/bin/ld"
+ln -s "/root/osxcross/target/bin/x86_64-apple-darwin17-otool" "/root/osxcross/target/bin/otool"
+ln -s "/root/osxcross/target/bin/x86_64-apple-darwin17-ranlib" "/root/osxcross/target/bin/ranlib"
+ln -s "/root/osxcross/target/bin/x86_64-apple-darwin17-ar" "/root/osxcross/target/bin/ar"
+ln -s "/root/osxcross/target/bin/x86_64-apple-darwin17-as" "/root/osxcross/target/bin/as"
+ln -s "/root/osxcross/target/bin/x86_64-apple-darwin17-install_name_tool" "/root/osxcross/target/bin/install_name_tool"
 
-export CC="clang-7 -O3 -target x86_64-apple-darwin15 -mlinker-version=0.0 -mmacosx-version-min=10.8 -B/root/osxcross/target/bin/ -isysroot/root/osxcross/target/SDK/MacOSX$FRAMEWORK.sdk/  -F/root/osxcross/target/macports/pkgs/opt/local/Library/Frameworks"
+export CC="clang-7 -O3 -target x86_64-apple-darwin17 -mlinker-version=0.0 -mmacosx-version-min=10.8 -B/root/osxcross/target/bin/ -isysroot/root/osxcross/target/SDK/MacOSX$FRAMEWORK.sdk/  -F/root/osxcross/target/macports/pkgs/opt/local/Library/Frameworks"
 
 
 ## This hack will allow winegcc to use the right compiler
-echo '$CC "$@"' > "/root/osxcross/target/bin/x86_64-apple-darwin15-gcc"
-chmod +x "/root/osxcross/target/bin/x86_64-apple-darwin15-gcc"
+echo '$CC "$@"' > "/root/osxcross/target/bin/x86_64-apple-darwin17-gcc"
+chmod +x "/root/osxcross/target/bin/x86_64-apple-darwin17-gcc"
 
 echo "[STAGE 3/11] Installing vkd3d"
 bash "/root/install_vkd3d.sh" "$VKD3D"
@@ -36,8 +35,9 @@ mkdir -p /root/hangover/build/wine-host
 cd /root/hangover/build/wine-host
 export C_INCLUDE_PATH="/root/osxcross/target/macports/pkgs/opt/local/include/:/root/osxcross/target/macports/pkgs/opt/local/include/libxml2/:/root/vkd3d/include/"
 export LIBRARY_PATH="/root/osxcross/target/macports/pkgs/opt/local/lib"
-../../wine/configure --enable-win64 --host x86_64-apple-darwin15 --prefix="/" --with-wine-tools="/root/hangover/build/wine-tools" LFFLAGS=" -Wl,-rpath,/opt/x11/lib -L/root/osxcross/target/macports/pkgs/opt/local/lib -F/root/osxcross/target/macports/pkgs/opt/local/Library/Frameworks"
+../../wine/configure --enable-win64 --host x86_64-apple-darwin17 --prefix="/" --with-wine-tools="/root/hangover/build/wine-tools" LFFLAGS=" -Wl,-rpath,/opt/x11/lib -L/root/osxcross/target/macports/pkgs/opt/local/lib -F/root/osxcross/target/macports/pkgs/opt/local/Library/Frameworks"
 make -j4
+ln -s /root/hangover/build/wine-host /root/wine
 make install DESTDIR="/root/wine"
 touch /root/hangover/build/wine-host/.built
 
@@ -70,14 +70,14 @@ make install DESTDIR="/root/hangover-build/i686-w64-mingw32/"
 mkdir -p /root/hangover/build/qemu
 
 
-ln -s "/root/osxcross/target/bin/x86_64-apple-darwin15-ld" "/root/osxcross/target/bin/ld"
-ln -s "/root/osxcross/target/bin/x86_64-apple-darwin15-otool" "/root/osxcross/target/bin/otool"
-ln -s "/root/osxcross/target/bin/x86_64-apple-darwin15-ranlib" "/root/osxcross/target/bin/ranlib"
-ln -s "/root/osxcross/target/bin/x86_64-apple-darwin15-ar" "/root/osxcross/target/bin/ar"
-ln -s "/root/osxcross/target/bin/x86_64-apple-darwin15-as" "/root/osxcross/target/bin/as"
-ln -s "/root/osxcross/target/bin/x86_64-apple-darwin15-install_name_tool" "/root/osxcross/target/bin/install_name_tool"
+ln -s "/root/osxcross/target/bin/x86_64-apple-darwin17-ld" "/root/osxcross/target/bin/ld"
+ln -s "/root/osxcross/target/bin/x86_64-apple-darwin17-otool" "/root/osxcross/target/bin/otool"
+ln -s "/root/osxcross/target/bin/x86_64-apple-darwin17-ranlib" "/root/osxcross/target/bin/ranlib"
+ln -s "/root/osxcross/target/bin/x86_64-apple-darwin17-ar" "/root/osxcross/target/bin/ar"
+ln -s "/root/osxcross/target/bin/x86_64-apple-darwin17-as" "/root/osxcross/target/bin/as"
+ln -s "/root/osxcross/target/bin/x86_64-apple-darwin17-install_name_tool" "/root/osxcross/target/bin/install_name_tool"
 
-export CC="clang-7 -O3 -target x86_64-apple-darwin15 -mlinker-version=0.0 -mmacosx-version-min=10.8 -B/root/osxcross/target/bin/ -isysroot/root/osxcross/target/SDK/MacOSX$FRAMEWORK.sdk/  -F/root/osxcross/target/macports/pkgs/opt/local/Library/Frameworks"
+export CC="clang-7 -O3 -target x86_64-apple-darwin17 -mlinker-version=0.0 -mmacosx-version-min=10.8 -B/root/osxcross/target/bin/ -isysroot/root/osxcross/target/SDK/MacOSX$FRAMEWORK.sdk/  -F/root/osxcross/target/macports/pkgs/opt/local/Library/Frameworks"
 
 mkdir -p /root/hangover/bin/
 touch /root/hangover/bin/Rez
@@ -89,24 +89,24 @@ omp install glib2-devel
 
 cat << EOF > /root/hangover/bin/qemugcc
 #!/bin/bash
-export CC="clang-7 -O3 -target x86_64-apple-darwin15 -mlinker-version=0.0 -mmacosx-version-min=10.8 -B/root/osxcross/target/bin/ -isysroot/root/osxcross/target/SDK/MacOSX$FRAMEWORK.sdk/  -F/root/osxcross/target/macports/pkgs/opt/local/Library/Frameworks"
-/root/hangover/build/wine-tools/tools/winegcc/winegcc -b x86_64-apple-darwin15  -B/root/hangover/build/wine-tools/tools/winebuild/ -I/root/hangover/build/wine-tools/include/ -I/root/hangover/wine/include -lpthread -DWINE_NOWINSOCK -I/root/osxcross/target/macports/pkgs/opt/local/include/glib-2.0/ -I/root/hangover/glib/glib/ -L/root/osxcross/target/macports/pkgs/opt/local/lib --sysroot=/root/hangover/build/wine-host/ "\$@"
+export CC="clang-7 -O3 -target x86_64-apple-darwin17 -mlinker-version=0.0 -mmacosx-version-min=10.8 -B/root/osxcross/target/bin/ -isysroot/root/osxcross/target/SDK/MacOSX$FRAMEWORK.sdk/  -F/root/osxcross/target/macports/pkgs/opt/local/Library/Frameworks"
+/root/hangover/build/wine-tools/tools/winegcc/winegcc -b x86_64-apple-darwin17  -B/root/hangover/build/wine-tools/tools/winebuild/ -I/root/hangover/build/wine-tools/include/ -I/root/hangover/wine/include -lpthread -DWINE_NOWINSOCK -I/root/osxcross/target/macports/pkgs/opt/local/include/glib-2.0/ -I/root/hangover/glib/glib/ -L/root/osxcross/target/macports/pkgs/opt/local/lib --sysroot=/root/hangover/build/wine-host/ "\$@"
 EOF
 chmod +x /root/hangover/bin/qemugcc
 
 
 cat << EOF > /root/hangover/bin/qemug++
 #!/bin/bash
-export CC="clang-7 -O3 -target x86_64-apple-darwin15 -mlinker-version=0.0 -mmacosx-version-min=10.8 -B/root/osxcross/target/bin/ -isysroot/root/osxcross/target/SDK/MacOSX$FRAMEWORK.sdk/  -F/root/osxcross/target/macports/pkgs/opt/local/Library/Frameworks"
-export CXX="clang-7 -O3 -target x86_64-apple-darwin15 -mlinker-version=0.0 -mmacosx-version-min=10.8 -B/root/osxcross/target/bin/ -isysroot/root/osxcross/target/SDK/MacOSX$FRAMEWORK.sdk/  -F/root/osxcross/target/macports/pkgs/opt/local/Library/Frameworks"
-/root/hangover/build/wine-tools/tools/winegcc/wineg++ -b x86_64-apple-darwin15 -B/root/hangover/build/wine-tools/tools/winebuild -I/root/hangover/build/wine-tools/include -I/root/hangover/wine/include -lpthread -DWINE_NOWINSOCK -I/root/osxcross/target/macports/pkgs/opt/local/include/glib-2.0/ -I/root/hangover/glib/glib/ --sysroot=/root/hangover/build/wine-host/ -L/root/osxcross/target/macports/pkgs/opt/local/lib "\$@"
+export CC="clang-7 -O3 -target x86_64-apple-darwin17 -mlinker-version=0.0 -mmacosx-version-min=10.8 -B/root/osxcross/target/bin/ -isysroot/root/osxcross/target/SDK/MacOSX$FRAMEWORK.sdk/  -F/root/osxcross/target/macports/pkgs/opt/local/Library/Frameworks"
+export CXX="clang-7 -O3 -target x86_64-apple-darwin17 -mlinker-version=0.0 -mmacosx-version-min=10.8 -B/root/osxcross/target/bin/ -isysroot/root/osxcross/target/SDK/MacOSX$FRAMEWORK.sdk/  -F/root/osxcross/target/macports/pkgs/opt/local/Library/Frameworks"
+/root/hangover/build/wine-tools/tools/winegcc/wineg++ -b x86_64-apple-darwin17 -B/root/hangover/build/wine-tools/tools/winebuild -I/root/hangover/build/wine-tools/include -I/root/hangover/wine/include -lpthread -DWINE_NOWINSOCK -I/root/osxcross/target/macports/pkgs/opt/local/include/glib-2.0/ -I/root/hangover/glib/glib/ --sysroot=/root/hangover/build/wine-host/ -L/root/osxcross/target/macports/pkgs/opt/local/lib "\$@"
 EOF
 chmod +x /root/hangover/bin/qemug++
 
 cat << EOF > /root/hangover/bin/dllgcc
 #!/bin/bash
-export CC="clang-7 -O3 -target x86_64-apple-darwin15 -mlinker-version=0.0 -mmacosx-version-min=10.8 -B/root/osxcross/target/bin/ -isysroot/root/osxcross/target/SDK/MacOSX$FRAMEWORK.sdk/  -F/root/osxcross/target/macports/pkgs/opt/local/Library/Frameworks"
-/root/hangover/build/wine-tools/tools/winegcc/winegcc -b x86_64-apple-darwin15  -B/root/hangover/build/wine-tools/tools/winebuild/ -I/root/hangover/build/wine-host/include/ -I/root/hangover/wine/include --sysroot=/root/hangover/build/wine-host/ "\$@"
+export CC="clang-7 -O3 -target x86_64-apple-darwin17 -mlinker-version=0.0 -mmacosx-version-min=10.8 -B/root/osxcross/target/bin/ -isysroot/root/osxcross/target/SDK/MacOSX$FRAMEWORK.sdk/  -F/root/osxcross/target/macports/pkgs/opt/local/Library/Frameworks"
+/root/hangover/build/wine-tools/tools/winegcc/winegcc -b x86_64-apple-darwin17  -B/root/hangover/build/wine-tools/tools/winebuild/ -I/root/hangover/build/wine-host/include/ -I/root/hangover/wine/include --sysroot=/root/hangover/build/wine-host/ "\$@"
 EOF
 chmod +x /root/hangover/bin/dllgcc
 

--- a/builders/scripts/builder_darwin_mac32_wine
+++ b/builders/scripts/builder_darwin_mac32_wine
@@ -4,7 +4,7 @@ cp -a "/root/wine-git" "/root/wine-tools" || exit 1
 ####### Build Tools
 echo "[STAGE 1/11] Configure tools"
 cd "/root/wine-tools"
-./configure --enable-win64 || exit 2
+./configure --without-unwind --enable-win64 || exit 2
 
 echo "[STAGE 2/11] Make tools"
 make __tooldeps__ -j 4 || exit 3
@@ -170,10 +170,6 @@ rm libxcb.1.dylib
 rm libxcb.dylib
 rm libxslt.1.dylib
 rm libxslt.dylib
-
-# remove libunwind not needed at runtime
-rm libunwind.dylib
-rm libunwind.1.dylib
 
 ## Fixing imports
 echo "[STAGE 11/11] Fixing imports"

--- a/builders/scripts/builder_darwin_mac32_wine
+++ b/builders/scripts/builder_darwin_mac32_wine
@@ -17,31 +17,30 @@ chmod +x winebuild
 ####### Build wine
 ### Environment preparation
 mkdir -p "/root/wine-git/wine32-build/"
-export FRAMEWORK="10.11"
 
 ## Some tools are not directly found by wine
-ln -s "/root/osxcross/target/bin/x86_64-apple-darwin15-ld" "/root/osxcross/target/bin/ld"
-ln -s "/root/osxcross/target/bin/x86_64-apple-darwin15-otool" "/root/osxcross/target/bin/otool"
-ln -s "/root/osxcross/target/bin/x86_64-apple-darwin15-ranlib" "/root/osxcross/target/bin/ranlib"
-ln -s "/root/osxcross/target/bin/x86_64-apple-darwin15-ar" "/root/osxcross/target/bin/ar"
-ln -s "/root/osxcross/target/bin/x86_64-apple-darwin15-as" "/root/osxcross/target/bin/as"
-ln -s "/root/osxcross/target/bin/x86_64-apple-darwin15-install_name_tool" "/root/osxcross/target/bin/install_name_tool"
+ln -s "/root/osxcross/target/bin/x86_64-apple-darwin17-ld" "/root/osxcross/target/bin/ld"
+ln -s "/root/osxcross/target/bin/x86_64-apple-darwin17-otool" "/root/osxcross/target/bin/otool"
+ln -s "/root/osxcross/target/bin/x86_64-apple-darwin17-ranlib" "/root/osxcross/target/bin/ranlib"
+ln -s "/root/osxcross/target/bin/x86_64-apple-darwin17-ar" "/root/osxcross/target/bin/ar"
+ln -s "/root/osxcross/target/bin/x86_64-apple-darwin17-as" "/root/osxcross/target/bin/as"
+ln -s "/root/osxcross/target/bin/x86_64-apple-darwin17-install_name_tool" "/root/osxcross/target/bin/install_name_tool"
 
 #### Wine
 export C_INCLUDE_PATH="/root/osxcross/target/macports/pkgs/opt/local/include/:/root/osxcross/target/macports/pkgs/opt/local/include/libxml2/:/root/vkd3d/include/"
 export LIBRARY_PATH="/root/osxcross/target/macports/pkgs/opt/local/lib"
 
 #### 32bits
-export CC="clang-7 -mwine32 -O3 -target i386-apple-darwin15 -mlinker-version=0.0 -mmacosx-version-min=10.8 -B/root/osxcross/target/bin/ -isysroot/root/osxcross/target/SDK/MacOSX$FRAMEWORK.sdk/ -F/root/osxcross/target/macports/pkgs/opt/local/Library/Frameworks"
+export CC="clang-7 -mwine32 -O3 -target i386-apple-darwin17 -mlinker-version=0.0 -mmacosx-version-min=10.8 -B/root/osxcross/target/bin/ -isysroot/root/osxcross/target/SDK/MacOSX$FRAMEWORK.sdk/ -F/root/osxcross/target/macports/pkgs/opt/local/Library/Frameworks"
 ## This hack will allow winegcc to use the right compiler
-echo '$CC "$@"' > "/root/osxcross/target/bin/x86_64-apple-darwin15-gcc"
-chmod +x "/root/osxcross/target/bin/x86_64-apple-darwin15-gcc"
-echo '$CC "$@"' > "/root/osxcross/target/bin/i386-apple-darwin15-gcc"
-chmod +x "/root/osxcross/target/bin/i386-apple-darwin15-gcc"
+echo '$CC "$@"' > "/root/osxcross/target/bin/x86_64-apple-darwin17-gcc"
+chmod +x "/root/osxcross/target/bin/x86_64-apple-darwin17-gcc"
+echo '$CC "$@"' > "/root/osxcross/target/bin/i386-apple-darwin17-gcc"
+chmod +x "/root/osxcross/target/bin/i386-apple-darwin17-gcc"
 
 cd "/root/wine-git/wine32-build/"
 echo "[STAGE 6/11] Configure 32 bits"
-../configure --host i386-apple-darwin15 --prefix="/" --with-wine-tools="/root/wine-tools" LFFLAGS=" -Wl,-rpath,/opt/x11/lib -L/root/osxcross/target/macports/pkgs/opt/local/lib" || exit 4
+../configure --host i386-apple-darwin17 --prefix="/" --with-wine-tools="/root/wine-tools" LFFLAGS=" -Wl,-rpath,/opt/x11/lib -L/root/osxcross/target/macports/pkgs/opt/local/lib" || exit 4
 
 echo "[STAGE 7/11] Make 32 bits"
 make -j 4 || exit 5
@@ -171,6 +170,10 @@ rm libxcb.1.dylib
 rm libxcb.dylib
 rm libxslt.1.dylib
 rm libxslt.dylib
+
+# remove libunwind not needed at runtime
+rm libunwind.dylib
+rm libunwind.1.dylib
 
 ## Fixing imports
 echo "[STAGE 11/11] Fixing imports"

--- a/builders/scripts/builder_darwin_mac32_wine
+++ b/builders/scripts/builder_darwin_mac32_wine
@@ -168,8 +168,6 @@ rm libxcb-xvmc.0.dylib
 rm libxcb-xvmc.dylib
 rm libxcb.1.dylib
 rm libxcb.dylib
-rm libxslt.1.dylib
-rm libxslt.dylib
 
 ## Fixing imports
 echo "[STAGE 11/11] Fixing imports"

--- a/builders/scripts/builder_darwin_mac64_wine
+++ b/builders/scripts/builder_darwin_mac64_wine
@@ -4,7 +4,7 @@ cp -a "/root/wine-git" "/root/wine-tools" || exit 1
 ####### Build Tools
 echo "[STAGE 1/11] Configure tools"
 cd "/root/wine-tools"
-./configure --enable-win64 || exit 2
+./configure --without-unwind --enable-win64 || exit 2
 
 echo "[STAGE 2/11] Make tools"
 make __tooldeps__ -j 4 || exit 3
@@ -44,7 +44,7 @@ export LIBRARY_PATH="/root/osxcross/target/macports/pkgs/opt/local/lib"
 
 cd "/root/wine-git/wine64-build/"
 echo "[STAGE 4/11] Configure 64 bits"
-../configure --enable-win64 --host x86_64-apple-darwin17 --prefix="/" --with-wine-tools="/root/wine-tools64" LFFLAGS=" -Wl,-rpath,/opt/x11/lib -L/root/osxcross/target/macports/pkgs/opt/local/lib -F/root/osxcross/target/macports/pkgs/opt/local/Library/Frameworks" || exit 5
+../configure --without-unwind --enable-win64 --host x86_64-apple-darwin17 --prefix="/" --with-wine-tools="/root/wine-tools64" LFFLAGS=" -Wl,-rpath,/opt/x11/lib -L/root/osxcross/target/macports/pkgs/opt/local/lib -F/root/osxcross/target/macports/pkgs/opt/local/Library/Frameworks" || exit 5
 echo "[STAGE 5/11] Make 64 bits"
 make -j 4 || exit 6
 
@@ -190,10 +190,6 @@ rm libxcb.1.dylib
 rm libxcb.dylib
 rm libxslt.1.dylib
 rm libxslt.dylib
-
-# remove libunwind not needed at runtime
-rm libunwind.dylib
-rm libunwind.1.dylib
 
 ## Fixing imports
 echo "[STAGE 11/11] Fixing imports"

--- a/builders/scripts/builder_darwin_mac64_wine
+++ b/builders/scripts/builder_darwin_mac64_wine
@@ -20,21 +20,20 @@ chmod +x winebuild
 ### Environment preparation
 mkdir -p "/root/wine-git/wine32-build/"
 mkdir -p "/root/wine-git/wine64-build/"
-export FRAMEWORK="10.11"
 
 ## Some tools are not directly found by wine
-ln -s "/root/osxcross/target/bin/x86_64-apple-darwin15-ld" "/root/osxcross/target/bin/ld"
-ln -s "/root/osxcross/target/bin/x86_64-apple-darwin15-otool" "/root/osxcross/target/bin/otool"
-ln -s "/root/osxcross/target/bin/x86_64-apple-darwin15-ranlib" "/root/osxcross/target/bin/ranlib"
-ln -s "/root/osxcross/target/bin/x86_64-apple-darwin15-ar" "/root/osxcross/target/bin/ar"
-ln -s "/root/osxcross/target/bin/x86_64-apple-darwin15-as" "/root/osxcross/target/bin/as"
-ln -s "/root/osxcross/target/bin/x86_64-apple-darwin15-install_name_tool" "/root/osxcross/target/bin/install_name_tool"
+ln -s "/root/osxcross/target/bin/x86_64-apple-darwin17-ld" "/root/osxcross/target/bin/ld"
+ln -s "/root/osxcross/target/bin/x86_64-apple-darwin17-otool" "/root/osxcross/target/bin/otool"
+ln -s "/root/osxcross/target/bin/x86_64-apple-darwin17-ranlib" "/root/osxcross/target/bin/ranlib"
+ln -s "/root/osxcross/target/bin/x86_64-apple-darwin17-ar" "/root/osxcross/target/bin/ar"
+ln -s "/root/osxcross/target/bin/x86_64-apple-darwin17-as" "/root/osxcross/target/bin/as"
+ln -s "/root/osxcross/target/bin/x86_64-apple-darwin17-install_name_tool" "/root/osxcross/target/bin/install_name_tool"
 
 #### 64bits
-export CC="clang-7 -O3 -target x86_64-apple-darwin15 -mlinker-version=0.0 -mmacosx-version-min=10.8 -B/root/osxcross/target/bin/ -isysroot/root/osxcross/target/SDK/MacOSX$FRAMEWORK.sdk/  -F/root/osxcross/target/macports/pkgs/opt/local/Library/Frameworks"
+export CC="clang-7 -O3 -target x86_64-apple-darwin17 -mlinker-version=0.0 -mmacosx-version-min=10.8 -B/root/osxcross/target/bin/ -isysroot/root/osxcross/target/SDK/MacOSX$FRAMEWORK.sdk/  -F/root/osxcross/target/macports/pkgs/opt/local/Library/Frameworks"
 ## This hack will allow winegcc to use the right compiler
-echo '$CC "$@"' > "/root/osxcross/target/bin/x86_64-apple-darwin15-gcc"
-chmod +x "/root/osxcross/target/bin/x86_64-apple-darwin15-gcc"
+echo '$CC "$@"' > "/root/osxcross/target/bin/x86_64-apple-darwin17-gcc"
+chmod +x "/root/osxcross/target/bin/x86_64-apple-darwin17-gcc"
 
 ####### Install VKD3D
 echo "[STAGE 3/11] Installing vkd3d"
@@ -45,19 +44,19 @@ export LIBRARY_PATH="/root/osxcross/target/macports/pkgs/opt/local/lib"
 
 cd "/root/wine-git/wine64-build/"
 echo "[STAGE 4/11] Configure 64 bits"
-../configure --enable-win64 --host x86_64-apple-darwin15 --prefix="/" --with-wine-tools="/root/wine-tools64" LFFLAGS=" -Wl,-rpath,/opt/x11/lib -L/root/osxcross/target/macports/pkgs/opt/local/lib -F/root/osxcross/target/macports/pkgs/opt/local/Library/Frameworks" || exit 5
+../configure --enable-win64 --host x86_64-apple-darwin17 --prefix="/" --with-wine-tools="/root/wine-tools64" LFFLAGS=" -Wl,-rpath,/opt/x11/lib -L/root/osxcross/target/macports/pkgs/opt/local/lib -F/root/osxcross/target/macports/pkgs/opt/local/Library/Frameworks" || exit 5
 echo "[STAGE 5/11] Make 64 bits"
 make -j 4 || exit 6
 
 #### 32bits
-export CC="clang-7 -mwine32 -O3 -target i386-apple-darwin15 -mlinker-version=0.0 -mmacosx-version-min=10.8 -B/root/osxcross/target/bin/ -isysroot/root/osxcross/target/SDK/MacOSX$FRAMEWORK.sdk/ -F/root/osxcross/target/macports/pkgs/opt/local/Library/Frameworks"
+export CC="clang-7 -mwine32 -O3 -target i386-apple-darwin17 -mlinker-version=0.0 -mmacosx-version-min=10.8 -B/root/osxcross/target/bin/ -isysroot/root/osxcross/target/SDK/MacOSX$FRAMEWORK.sdk/ -F/root/osxcross/target/macports/pkgs/opt/local/Library/Frameworks"
 ## This hack will allow winegcc to use the right compiler
-echo '$CC "$@"' > "/root/osxcross/target/bin/i386-apple-darwin15-gcc"
-chmod +x "/root/osxcross/target/bin/i386-apple-darwin15-gcc"
+echo '$CC "$@"' > "/root/osxcross/target/bin/i386-apple-darwin17-gcc"
+chmod +x "/root/osxcross/target/bin/i386-apple-darwin17-gcc"
 
 cd "/root/wine-git/wine32-build/"
 echo "[STAGE 6/11] Configure 32 bits"
-../configure --with-wine64=/root/wine-git/wine64-build --host i386-apple-darwin15 --prefix="/" --with-wine-tools="/root/wine-tools" LFFLAGS=" -Wl,-rpath,/opt/x11/lib -L/root/osxcross/target/macports/pkgs/opt/local/lib" || exit 7
+../configure --with-wine64=/root/wine-git/wine64-build --host i386-apple-darwin17 --prefix="/" --with-wine-tools="/root/wine-tools" LFFLAGS=" -Wl,-rpath,/opt/x11/lib -L/root/osxcross/target/macports/pkgs/opt/local/lib" || exit 7
 
 echo "[STAGE 7/11] Make 32 bits"
 make -j 4 || exit 8
@@ -191,6 +190,10 @@ rm libxcb.1.dylib
 rm libxcb.dylib
 rm libxslt.1.dylib
 rm libxslt.dylib
+
+# remove libunwind not needed at runtime
+rm libunwind.dylib
+rm libunwind.1.dylib
 
 ## Fixing imports
 echo "[STAGE 11/11] Fixing imports"

--- a/builders/scripts/builder_darwin_mac64_wine
+++ b/builders/scripts/builder_darwin_mac64_wine
@@ -188,8 +188,6 @@ rm libxcb-xvmc.0.dylib
 rm libxcb-xvmc.dylib
 rm libxcb.1.dylib
 rm libxcb.dylib
-rm libxslt.1.dylib
-rm libxslt.dylib
 
 ## Fixing imports
 echo "[STAGE 11/11] Fixing imports"

--- a/builders/scripts/builder_darwin_x86_runtime
+++ b/builders/scripts/builder_darwin_x86_runtime
@@ -123,8 +123,6 @@ rm libxcb-xvmc.0.dylib
 rm libxcb-xvmc.dylib
 rm libxcb.1.dylib
 rm libxcb.dylib
-rm libxslt.1.dylib
-rm libxslt.dylib
 
 ## Fixing imports
 bash /root/fix_imports.sh "/root/runtime"

--- a/builders/scripts/builder_darwin_x86_runtime
+++ b/builders/scripts/builder_darwin_x86_runtime
@@ -126,10 +126,6 @@ rm libxcb.dylib
 rm libxslt.1.dylib
 rm libxslt.dylib
 
-# remove libunwind not needed at runtime
-rm libunwind.dylib
-rm libunwind.1.dylib
-
 ## Fixing imports
 bash /root/fix_imports.sh "/root/runtime"
 

--- a/builders/scripts/builder_darwin_x86_runtime
+++ b/builders/scripts/builder_darwin_x86_runtime
@@ -1,6 +1,6 @@
 #!/bin/bash
-ln -s "/root/osxcross/target/bin/i386-apple-darwin15-install_name_tool" "/root/osxcross/target/bin/install_name_tool"
-ln -s "/root/osxcross/target/bin/i386-apple-darwin15-otool" "/root/osxcross/target/bin/otool"
+ln -s "/root/osxcross/target/bin/i386-apple-darwin17-install_name_tool" "/root/osxcross/target/bin/install_name_tool"
+ln -s "/root/osxcross/target/bin/i386-apple-darwin17-otool" "/root/osxcross/target/bin/otool"
 
 mkdir -p /root/runtime/lib
 cd "/root/runtime/lib/"
@@ -126,12 +126,16 @@ rm libxcb.dylib
 rm libxslt.1.dylib
 rm libxslt.dylib
 
+# remove libunwind not needed at runtime
+rm libunwind.dylib
+rm libunwind.1.dylib
+
 ## Fixing imports
 bash /root/fix_imports.sh "/root/runtime"
 
 ## To make package smaller, we are only going to keep i386 part of the libraries
 for file in *.dylib; do
-  [ ! -L "$file" ] && i386-apple-darwin15-lipo -extract i386 "$file" -o "$file" 2> /dev/null
+  [ ! -L "$file" ] && i386-apple-darwin17-lipo -extract i386 "$file" -o "$file" 2> /dev/null
 done
 
 echo "[END]"

--- a/builders/scripts/builder_darwin_x86_wine
+++ b/builders/scripts/builder_darwin_x86_wine
@@ -171,10 +171,6 @@ rm libxcb.dylib
 rm libxslt.1.dylib
 rm libxslt.dylib
 
-# remove libunwind not needed at runtime
-rm libunwind.dylib
-rm libunwind.1.dylib
-
 ## Fixing imports
 echo "[STAGE 8/8] Fixing imports"
 bash /root/fix_imports.sh "/root/wine"

--- a/builders/scripts/builder_darwin_x86_wine
+++ b/builders/scripts/builder_darwin_x86_wine
@@ -19,26 +19,25 @@ chmod +x winebuild
 ####### Build wine
 cd "/root/wine-git"
 ## Environment preparation
-export FRAMEWORK="10.11"
-export CC="clang-7 -O3 -target i386-apple-darwin15 -mmacosx-version-min=10.8 -B/root/osxcross/target/bin/ -isysroot/root/osxcross/target/SDK/MacOSX$FRAMEWORK.sdk/  -F/root/osxcross/target/macports/pkgs/opt/local/Library/Frameworks/"
+export CC="clang-7 -O3 -target i386-apple-darwin17 -mmacosx-version-min=10.8 -B/root/osxcross/target/bin/ -isysroot/root/osxcross/target/SDK/MacOSX$FRAMEWORK.sdk/  -F/root/osxcross/target/macports/pkgs/opt/local/Library/Frameworks/ -Wno-unused-command-line-argument -Wno-deprecated-declarations"
 export C_INCLUDE_PATH="$C_INCLUDE_PATH:/root/osxcross/target/macports/pkgs/opt/local/include/:/root/osxcross/target/macports/pkgs/opt/local/include/libxml2/"
 export LIBRARY_PATH="$LIBRARY_PATH:/root/osxcross/target/macports/pkgs/opt/local/lib"
 
 ## This hack will allow winegcc to use the right compiler
-echo '$CC "$@"' > "/root/osxcross/target/bin/i386-apple-darwin15-gcc"
-chmod +x "/root/osxcross/target/bin/i386-apple-darwin15-gcc"
+echo '$CC "$@"' > "/root/osxcross/target/bin/i386-apple-darwin17-gcc"
+chmod +x "/root/osxcross/target/bin/i386-apple-darwin17-gcc"
 
 ## Some tools are not directly found by wine
-ln -s "/root/osxcross/target/bin/i386-apple-darwin15-ld" "/root/osxcross/target/bin/ld"
-ln -s "/root/osxcross/target/bin/i386-apple-darwin15-otool" "/root/osxcross/target/bin/otool"
-ln -s "/root/osxcross/target/bin/i386-apple-darwin15-ranlib" "/root/osxcross/target/bin/ranlib"
-ln -s "/root/osxcross/target/bin/i386-apple-darwin15-ar" "/root/osxcross/target/bin/ar"
-ln -s "/root/osxcross/target/bin/i386-apple-darwin15-as" "/root/osxcross/target/bin/as"
-ln -s "/root/osxcross/target/bin/i386-apple-darwin15-install_name_tool" "/root/osxcross/target/bin/install_name_tool"
+ln -s "/root/osxcross/target/bin/i386-apple-darwin17-ld" "/root/osxcross/target/bin/ld"
+ln -s "/root/osxcross/target/bin/i386-apple-darwin17-otool" "/root/osxcross/target/bin/otool"
+ln -s "/root/osxcross/target/bin/i386-apple-darwin17-ranlib" "/root/osxcross/target/bin/ranlib"
+ln -s "/root/osxcross/target/bin/i386-apple-darwin17-ar" "/root/osxcross/target/bin/ar"
+ln -s "/root/osxcross/target/bin/i386-apple-darwin17-as" "/root/osxcross/target/bin/as"
+ln -s "/root/osxcross/target/bin/i386-apple-darwin17-install_name_tool" "/root/osxcross/target/bin/install_name_tool"
 
 echo "[STAGE 4/8] Configure"
 
-./configure --host i386-apple-darwin15 --prefix="/" --with-wine-tools="/root/wine-tools" LFFLAGS=" -Wl,-rpath,/opt/x11/lib -L/root/osxcross/target/macports/pkgs/opt/local/lib -m32" || exit 4
+./configure --host i386-apple-darwin17 --prefix="/" --with-wine-tools="/root/wine-tools" LFFLAGS=" -Wl,-rpath,/opt/x11/lib -L/root/osxcross/target/macports/pkgs/opt/local/lib -m32" || exit 4
 
 echo "[STAGE 5/8] Make"
 numberOfSteps="$(make __builddeps__ --no-print-directory -nrRk 2> /dev/null|wc -l)"
@@ -171,6 +170,10 @@ rm libxcb.1.dylib
 rm libxcb.dylib
 rm libxslt.1.dylib
 rm libxslt.dylib
+
+# remove libunwind not needed at runtime
+rm libunwind.dylib
+rm libunwind.1.dylib
 
 ## Fixing imports
 echo "[STAGE 8/8] Fixing imports"

--- a/builders/scripts/builder_darwin_x86_wine
+++ b/builders/scripts/builder_darwin_x86_wine
@@ -168,8 +168,6 @@ rm libxcb-xvmc.0.dylib
 rm libxcb-xvmc.dylib
 rm libxcb.1.dylib
 rm libxcb.dylib
-rm libxslt.1.dylib
-rm libxslt.dylib
 
 ## Fixing imports
 echo "[STAGE 8/8] Fixing imports"

--- a/environments/darwin/install_vkd3d.sh
+++ b/environments/darwin/install_vkd3d.sh
@@ -9,7 +9,7 @@ export LIBRARY_PATH="/root/osxcross/target/macports/pkgs/opt/local/lib:/root/vul
 export PATH="/root/wine-tools64/tools/widl/:$PATH"
 
 ./autogen.sh || exit 1
-./configure --host x86_64-apple-darwin15 --prefix="/" LFFLAGS=" -Wl,-rpath,/opt/x11/lib -L/root/osxcross/target/macports/pkgs/opt/local/lib -F/root/osxcross/target/macports/pkgs/opt/local/Library/Frameworks" || exit 2
+./configure --host x86_64-apple-darwin17 --prefix="/" LFFLAGS=" -Wl,-rpath,/opt/x11/lib -L/root/osxcross/target/macports/pkgs/opt/local/lib -F/root/osxcross/target/macports/pkgs/opt/local/Library/Frameworks" || exit 2
 make || exit 3
 make install DESTDIR="/root/osxcross/target/macports/pkgs/opt/local/" || exit 4
 libtool --finish /root/osxcross/target/macports/pkgs/opt/local/lib || exit 5

--- a/environments/linux-amd64-wine_osxcross
+++ b/environments/linux-amd64-wine_osxcross
@@ -14,15 +14,12 @@ RUN apt-get -y install libjs-mathjax python-yaml lib32gcc1 lib32stdc++6 libc6-i3
 RUN dpkg -i *.deb
 
 RUN git clone https://github.com/tpoechtrager/osxcross /root/osxcross
-COPY darwin/SDK/MacOSX10.11.sdk.tar.xz /root/osxcross/tarballs/
+COPY darwin/SDK/MacOSX10.13.sdk.tar.xz /root/osxcross/tarballs/
 RUN cd /root/osxcross && UNATTENDED=1 ./build.sh
 
 ENV PATH="/root/osxcross/target/bin:${PATH}"
 ENV MACOSX_DEPLOYMENT_TARGET="10.11"
-ENV FRAMEWORK="10.11"
-ENV FAUDIO="19.06"
-ENV MOLTENVK="1.1.106.0"
-ENV VKD3D="vkd3d-1.1"
+ENV FRAMEWORK="10.13"
 
 RUN mkdir -p /root/osxcross/target/macports
 RUN printf "packages.macports.org" > /root/osxcross/target/macports/MIRROR
@@ -48,9 +45,9 @@ RUN tar -xvf  ncurses-6.1.tar.gz
 WORKDIR /root/ncurses/ncurses-6.1
 
 ### NCurses 32Bit
-RUN ln -s "/root/osxcross/target/bin/i386-apple-darwin15-strip" "/root/osxcross/target/bin/strip"
-ENV CC_OSX="clang -O3 -target i386-apple-darwin15 -mmacosx-version-min=10.8 -B/root/osxcross/target/bin/ -isysroot/root/osxcross/target/SDK/MacOSX$FRAMEWORK.sdk/  -F/root/osxcross/target/macports/pkgs/opt/local/Library/Frameworks/"
-RUN env CC="$CC_OSX" ./configure --host i386-apple-darwin15 --with-shared --enable-widec --disable-lib-suffixes --enable-overwrite --without-debug --without-ada  --with-manpage-format=normal --enable-pc-files --disable-mixed-case  --prefix="/root/osxcross/target/macports/pkgs/opt/local" --enable-rpath --datarootdir=/usr/share
+RUN ln -s "/root/osxcross/target/bin/i386-apple-darwin17-strip" "/root/osxcross/target/bin/strip"
+ENV CC_OSX="clang -O3 -target i386-apple-darwin17 -mmacosx-version-min=10.8 -B/root/osxcross/target/bin/ -isysroot/root/osxcross/target/SDK/MacOSX$FRAMEWORK.sdk/  -F/root/osxcross/target/macports/pkgs/opt/local/Library/Frameworks/"
+RUN env CC="$CC_OSX" ./configure --host i386-apple-darwin17 --with-shared --enable-widec --disable-lib-suffixes --enable-overwrite --without-debug --without-ada  --with-manpage-format=normal --enable-pc-files --disable-mixed-case  --prefix="/root/osxcross/target/macports/pkgs/opt/local" --enable-rpath --datarootdir=/usr/share
 RUN env CC="$CC_OSX" make -j 4
 RUN env CC="$CC_OSX" make install
 RUN rm "/root/osxcross/target/bin/strip"
@@ -58,29 +55,30 @@ RUN mv /root/osxcross/target/macports/pkgs/opt/local/lib/libncurses.6.dylib /roo
 
 ### NCurses 64Bit
 RUN env CC="$CC_OSX" make clean
-RUN ln -s "/root/osxcross/target/bin/x86_64-apple-darwin15-strip" "/root/osxcross/target/bin/strip"
-ENV CC_OSX="clang -O3 -target x86_64-apple-darwin15 -mmacosx-version-min=10.8 -B/root/osxcross/target/bin/ -isysroot/root/osxcross/target/SDK/MacOSX$FRAMEWORK.sdk/  -F/root/osxcross/target/macports/pkgs/opt/local/Library/Frameworks/"
-RUN env CC="$CC_OSX" ./configure --host x86_64-apple-darwin15 --with-shared --enable-widec --disable-lib-suffixes --enable-overwrite --without-debug --without-ada  --with-manpage-format=normal --enable-pc-files --disable-mixed-case  --prefix="/root/osxcross/target/macports/pkgs/opt/local" --enable-rpath --datarootdir=/usr/share
+RUN ln -s "/root/osxcross/target/bin/x86_64-apple-darwin17-strip" "/root/osxcross/target/bin/strip"
+ENV CC_OSX="clang -O3 -target x86_64-apple-darwin17 -mmacosx-version-min=10.8 -B/root/osxcross/target/bin/ -isysroot/root/osxcross/target/SDK/MacOSX$FRAMEWORK.sdk/  -F/root/osxcross/target/macports/pkgs/opt/local/Library/Frameworks/"
+RUN env CC="$CC_OSX" ./configure --host x86_64-apple-darwin17 --with-shared --enable-widec --disable-lib-suffixes --enable-overwrite --without-debug --without-ada  --with-manpage-format=normal --enable-pc-files --disable-mixed-case  --prefix="/root/osxcross/target/macports/pkgs/opt/local" --enable-rpath --datarootdir=/usr/share
 RUN env CC="$CC_OSX" make -j 4
 RUN env CC="$CC_OSX" make install
 RUN rm "/root/osxcross/target/bin/strip"
 RUN mv /root/osxcross/target/macports/pkgs/opt/local/lib/libncurses.6.dylib /root/osxcross/target/macports/pkgs/opt/local/lib64/
 
 ### Merge the NCurses into a single file
-RUN x86_64-apple-darwin15-lipo /root/osxcross/target/macports/pkgs/opt/local/lib32/libncurses.6.dylib /root/osxcross/target/macports/pkgs/opt/local/lib64/libncurses.6.dylib -output /root/osxcross/target/macports/pkgs/opt/local/lib/libncurses.6.dylib -create
+RUN x86_64-apple-darwin17-lipo /root/osxcross/target/macports/pkgs/opt/local/lib32/libncurses.6.dylib /root/osxcross/target/macports/pkgs/opt/local/lib64/libncurses.6.dylib -output /root/osxcross/target/macports/pkgs/opt/local/lib/libncurses.6.dylib -create
 
 ### SDL2 Source code
 # We need to build manually SDL2 as macports does not have a universal version for download but we need one.
+ENV SDL2="SDL2-2.0.9"
 RUN mkdir /root/sdl2
 WORKDIR /root/sdl2
-RUN wget https://www.libsdl.org/release/SDL2-2.0.9.tar.gz
-RUN tar -xvf  SDL2-2.0.9.tar.gz
-WORKDIR /root/sdl2/SDL2-2.0.9
+RUN wget https://www.libsdl.org/release/${SDL2}.tar.gz
+RUN tar -xvf  ${SDL2}.tar.gz
+WORKDIR /root/sdl2/${SDL2}
 
 ### SDL2 32Bit
-RUN ln -s "/root/osxcross/target/bin/i386-apple-darwin15-strip" "/root/osxcross/target/bin/strip"
-ENV CC_OSX="clang -O3 -target i386-apple-darwin15 -mmacosx-version-min=10.8 -B/root/osxcross/target/bin/ -isysroot/root/osxcross/target/SDK/MacOSX$FRAMEWORK.sdk/  -F/root/osxcross/target/macports/pkgs/opt/local/Library/Frameworks/"
-RUN env CC="$CC_OSX" ./configure --host i386-apple-darwin15  --prefix="/root/osxcross/target/macports/pkgs/opt/local"
+RUN ln -s "/root/osxcross/target/bin/i386-apple-darwin17-strip" "/root/osxcross/target/bin/strip"
+ENV CC_OSX="clang-7 -O3 -target i386-apple-darwin17 -mmacosx-version-min=10.8 -B/root/osxcross/target/bin/ -isysroot/root/osxcross/target/SDK/MacOSX$FRAMEWORK.sdk/  -F/root/osxcross/target/macports/pkgs/opt/local/Library/Frameworks/"
+RUN env CC="$CC_OSX" ./configure --host i386-apple-darwin17  --prefix="/root/osxcross/target/macports/pkgs/opt/local"
 RUN env CC="$CC_OSX" make -j 4
 RUN env CC="$CC_OSX" make install-hdrs
 RUN env CC="$CC_OSX" make install-lib
@@ -89,10 +87,10 @@ RUN rm "/root/osxcross/target/bin/strip"
 RUN mv /root/osxcross/target/macports/pkgs/opt/local/lib/libSDL2-2.0.0.dylib /root/osxcross/target/macports/pkgs/opt/local/lib32/
 
 ### SDL2 64Bit
-RUN ln -s "/root/osxcross/target/bin/x86_64-apple-darwin15-strip" "/root/osxcross/target/bin/strip"
+RUN ln -s "/root/osxcross/target/bin/x86_64-apple-darwin17-strip" "/root/osxcross/target/bin/strip"
 RUN env CC="$CC_OSX" make clean
-ENV CC_OSX="clang -O3 -target x86_64-apple-darwin15 -mmacosx-version-min=10.8 -B/root/osxcross/target/bin/ -isysroot/root/osxcross/target/SDK/MacOSX$FRAMEWORK.sdk/  -F/root/osxcross/target/macports/pkgs/opt/local/Library/Frameworks/"
-RUN env CC="$CC_OSX" ./configure --host x86_64-apple-darwin15 --prefix="/root/osxcross/target/macports/pkgs/opt/local"
+ENV CC_OSX="clang-7 -O3 -target x86_64-apple-darwin17 -mmacosx-version-min=10.8 -B/root/osxcross/target/bin/ -isysroot/root/osxcross/target/SDK/MacOSX$FRAMEWORK.sdk/  -F/root/osxcross/target/macports/pkgs/opt/local/Library/Frameworks/"
+RUN env CC="$CC_OSX" ./configure --disable-render-metal --host x86_64-apple-darwin17 --prefix="/root/osxcross/target/macports/pkgs/opt/local"
 RUN env CC="$CC_OSX" make -j 4
 RUN env CC="$CC_OSX" make install-hdrs
 RUN env CC="$CC_OSX" make install-lib
@@ -101,9 +99,10 @@ RUN rm "/root/osxcross/target/bin/strip"
 RUN mv /root/osxcross/target/macports/pkgs/opt/local/lib/libSDL2-2.0.0.dylib /root/osxcross/target/macports/pkgs/opt/local/lib64/
 
 ### Merge the SDL2 into a single file
-RUN x86_64-apple-darwin15-lipo /root/osxcross/target/macports/pkgs/opt/local/lib32/libSDL2-2.0.0.dylib /root/osxcross/target/macports/pkgs/opt/local/lib64/libSDL2-2.0.0.dylib -output /root/osxcross/target/macports/pkgs/opt/local/lib/libSDL2-2.0.0.dylib -create
+RUN x86_64-apple-darwin17-lipo /root/osxcross/target/macports/pkgs/opt/local/lib32/libSDL2-2.0.0.dylib /root/osxcross/target/macports/pkgs/opt/local/lib64/libSDL2-2.0.0.dylib -output /root/osxcross/target/macports/pkgs/opt/local/lib/libSDL2-2.0.0.dylib -create
 
 ### Vulkan
+ENV MOLTENVK="1.1.114.0"
 WORKDIR /root/
 RUN wget https://sdk.lunarg.com/sdk/download/${MOLTENVK}/mac/vulkansdk-macos-${MOLTENVK}.tar.gz
 RUN tar -xvf vulkansdk-macos-${MOLTENVK}.tar.gz
@@ -117,6 +116,7 @@ RUN mv static/* /root/osxcross/target/macports/pkgs/opt/local/lib/
 RUN mv dynamic/* /root/osxcross/target/macports/pkgs/opt/local/lib/
 
 ### VK3D3
+ENV VKD3D="vkd3d-1.1"
 WORKDIR /root
 RUN git clone https://github.com/KhronosGroup/SPIRV-Headers
 RUN apt-get install -y libtool-bin
@@ -126,7 +126,8 @@ COPY darwin/install_vkd3d.sh /root/
 COPY darwin/fix_imports.sh /root/
 
 # Faudio
-RUN ln -s "/root/osxcross/target/bin/i386-apple-darwin15-ld" "/root/osxcross/target/bin/ld"
+ENV FAUDIO="19.08"
+RUN ln -s "/root/osxcross/target/bin/i386-apple-darwin17-ld" "/root/osxcross/target/bin/ld"
 RUN apt-get -y install cmake
 RUN mkdir -p /root/faudio
 WORKDIR /root/faudio
@@ -135,16 +136,16 @@ RUN mkdir -p /root/faudio/build64
 RUN mkdir -p /root/faudio/build32
 RUN mkdir -p /root/faudio/build
 WORKDIR /root/faudio/build64
-RUN env SDL2_DIR=/root/osxcross/target/macports/pkgs/opt/local/lib/cmake/SDL2 env CFLAGS="-O3 -msse2 -target x86_64-apple-darwin15 -mmacosx-version-min=10.8 -B/root/osxcross/target/bin/ -isysroot/root/osxcross/target/SDK/MacOSX$FRAMEWORK.sdk/ -F/root/osxcross/target/macports/pkgs/opt/local/Library/Frameworks/" cmake /root/faudio/FAudio -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang -DBUILD_CPP=OFF -DCMAKE_OSX_SYSROOT=/root/osxcross/target/SDK/MacOSX$FRAMEWORK.sdk  -DCMAKE_SYSTEM_NAME=Darwin -DCMAKE_FIND_ROOT_PATH=/root/osxcross/target/macports/pkgs/opt/local/
+RUN env SDL2_DIR=/root/osxcross/target/macports/pkgs/opt/local/lib/cmake/SDL2 env CFLAGS="-O3 -msse2 -target x86_64-apple-darwin17 -mmacosx-version-min=10.8 -B/root/osxcross/target/bin/ -isysroot/root/osxcross/target/SDK/MacOSX$FRAMEWORK.sdk/ -F/root/osxcross/target/macports/pkgs/opt/local/Library/Frameworks/" cmake /root/faudio/FAudio -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang -DBUILD_CPP=OFF -DCMAKE_OSX_SYSROOT=/root/osxcross/target/SDK/MacOSX$FRAMEWORK.sdk  -DCMAKE_SYSTEM_NAME=Darwin -DCMAKE_FIND_ROOT_PATH=/root/osxcross/target/macports/pkgs/opt/local/
 RUN make
 RUN make install DESTDIR=install/
 RUN cp install/usr/local/include/* /root/osxcross/target/macports/pkgs/opt/local/include
 
 WORKDIR /root/faudio/build32
-RUN env SDL2_DIR=/root/osxcross/target/macports/pkgs/opt/local/lib/cmake/SDL2 env CFLAGS="-O3 -msse2 -target i386-apple-darwin15 -mmacosx-version-min=10.8 -B/root/osxcross/target/bin/ -isysroot/root/osxcross/target/SDK/MacOSX$FRAMEWORK.sdk/ -F/root/osxcross/target/macports/pkgs/opt/local/Library/Frameworks/" cmake /root/faudio/FAudio -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang -DBUILD_CPP=OFF -DCMAKE_OSX_SYSROOT=/root/osxcross/target/SDK/MacOSX$FRAMEWORK.sdk  -DCMAKE_SYSTEM_NAME=Darwin -DCMAKE_FIND_ROOT_PATH=/root/osxcross/target/macports/pkgs/opt/local/
+RUN env SDL2_DIR=/root/osxcross/target/macports/pkgs/opt/local/lib/cmake/SDL2 env CFLAGS="-O3 -msse2 -target i386-apple-darwin17 -mmacosx-version-min=10.8 -B/root/osxcross/target/bin/ -isysroot/root/osxcross/target/SDK/MacOSX$FRAMEWORK.sdk/ -F/root/osxcross/target/macports/pkgs/opt/local/Library/Frameworks/" cmake /root/faudio/FAudio -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang -DBUILD_CPP=OFF -DCMAKE_OSX_SYSROOT=/root/osxcross/target/SDK/MacOSX$FRAMEWORK.sdk  -DCMAKE_SYSTEM_NAME=Darwin -DCMAKE_FIND_ROOT_PATH=/root/osxcross/target/macports/pkgs/opt/local/
 RUN make
 WORKDIR /root/faudio/build
-RUN x86_64-apple-darwin15-lipo ../build32/libFAudio.0.$FAUDIO.dylib ../build64/libFAudio.0.$FAUDIO.dylib -output libFAudio.0.$FAUDIO.dylib -create
+RUN x86_64-apple-darwin17-lipo ../build32/libFAudio.0.$FAUDIO.dylib ../build64/libFAudio.0.$FAUDIO.dylib -output libFAudio.0.$FAUDIO.dylib -create
 RUN ln -s libFAudio.0.$FAUDIO.dylib libFAudio.dylib
 RUN ln -s libFAudio.0.$FAUDIO.dylib libFAudio.0.dylib
 RUN cp -d *.dylib /root/osxcross/target/macports/pkgs/opt/local/lib
@@ -156,3 +157,5 @@ RUN rm -r /root/osxcross/target/macports/pkgs/opt/local/lib/wine
 RUN rm -r /root/osxcross/target/macports/pkgs/opt/local/include/wine/
 
 RUN apt-get -y install gcc-mingw-w64-i686 gcc-mingw-w64-x86-64
+RUN apt-get -y install libunwind-dev
+RUN osxcross-macports -universal install libunwind

--- a/environments/linux-amd64-wine_osxcross
+++ b/environments/linux-amd64-wine_osxcross
@@ -29,6 +29,8 @@ RUN printf "packages.macports.org" > /root/osxcross/target/macports/MIRROR
 RUN osxcross-macports -universal fakeinstall ncurses
 RUN osxcross-macports -universal fakeinstall pulseaudio
 RUN osxcross-macports fakeinstall MoltenVK
+RUN osxcross-macports -universal fakeinstall libxml2
+RUN osxcross-macports -universal fakeinstall libxslt
 RUN osxcross-macports -universal install wine-devel
 # RUN osxcross-macports -universal install gnutls
 
@@ -129,7 +131,6 @@ COPY darwin/fix_imports.sh /root/
 # Faudio
 ENV FAUDIO="19.08"
 RUN ln -s "/root/osxcross/target/bin/i386-apple-darwin17-ld" "/root/osxcross/target/bin/ld"
-RUN apt-get -y install cmake
 RUN mkdir -p /root/faudio
 WORKDIR /root/faudio
 RUN git clone -b "${FAUDIO}" https://github.com/FNA-XNA/FAudio

--- a/environments/linux-amd64-wine_osxcross
+++ b/environments/linux-amd64-wine_osxcross
@@ -68,7 +68,7 @@ RUN x86_64-apple-darwin17-lipo /root/osxcross/target/macports/pkgs/opt/local/lib
 
 ### SDL2 Source code
 # We need to build manually SDL2 as macports does not have a universal version for download but we need one.
-ENV SDL2="SDL2-2.0.9"
+ENV SDL2="SDL2-2.0.10"
 RUN mkdir /root/sdl2
 WORKDIR /root/sdl2
 RUN wget https://www.libsdl.org/release/${SDL2}.tar.gz

--- a/environments/linux-amd64-wine_osxcross
+++ b/environments/linux-amd64-wine_osxcross
@@ -18,7 +18,7 @@ COPY darwin/SDK/MacOSX10.13.sdk.tar.xz /root/osxcross/tarballs/
 RUN cd /root/osxcross && UNATTENDED=1 ./build.sh
 
 ENV PATH="/root/osxcross/target/bin:${PATH}"
-ENV MACOSX_DEPLOYMENT_TARGET="10.11"
+ENV MACOSX_DEPLOYMENT_TARGET="10.13"
 ENV FRAMEWORK="10.13"
 
 RUN mkdir -p /root/osxcross/target/macports
@@ -28,6 +28,7 @@ RUN printf "packages.macports.org" > /root/osxcross/target/macports/MIRROR
 # This will prevent wine-devel from installing it
 RUN osxcross-macports -universal fakeinstall ncurses
 RUN osxcross-macports -universal fakeinstall pulseaudio
+RUN osxcross-macports fakeinstall MoltenVK
 RUN osxcross-macports -universal install wine-devel
 # RUN osxcross-macports -universal install gnutls
 
@@ -157,5 +158,3 @@ RUN rm -r /root/osxcross/target/macports/pkgs/opt/local/lib/wine
 RUN rm -r /root/osxcross/target/macports/pkgs/opt/local/include/wine/
 
 RUN apt-get -y install gcc-mingw-w64-i686 gcc-mingw-w64-x86-64
-RUN apt-get -y install libunwind-dev
-RUN osxcross-macports -universal install libunwind


### PR DESCRIPTION
Wine now needs an external version of libunwind to compile or pass --without-unwind. So libunwind was added.
The unwind false positives should be resolved within Wine-4.16

10.13SDK is now required due to upstream wine changes, like the new Metal Multi-Monitor support (A patch will be added for Wine-4.16 to use support 10.11SDK but it was recommended to just build with 10.13SDK)

SDL2/MoltenVK/FAudio updated to current versions, added variable for SDL2 to make updating easy.
SDL2 needs to be build with clang-7 due to 10.13SDK being used and have metal backed disabled or it fails to build. (Id error)

All scripts updated and removed `ENV FRAMEWORK=` from builders, as it doesn't need to be called within each script.