### PR TITLE
Change to archived Debian Stretch URIs

### DIFF
--- a/environments/linux-amd64-wine
+++ b/environments/linux-amd64-wine
@@ -1,8 +1,12 @@
 FROM amd64/debian:stretch
 
-RUN echo 'deb-src http://deb.debian.org/debian stretch main' >> /etc/apt/sources.list
-RUN echo 'deb-src http://security.debian.org/debian-security stretch/updates main' >> /etc/apt/sources.list
-RUN echo 'deb-src http://deb.debian.org/debian stretch-updates main' >> /etc/apt/sources.list
+RUN echo 'deb http://archive.debian.org/debian stretch main' > /etc/apt/sources.list
+RUN echo 'deb http://archive.debian.org/debian-security stretch/updates main' >> /etc/apt/sources.list
+RUN echo 'deb http://archive.debian.org/debian stretch-proposed-updates main' >> /etc/apt/sources.list
+
+RUN echo 'deb-src http://archive.debian.org/debian stretch main' >> /etc/apt/sources.list
+RUN echo 'deb-src http://archive.debian.org/debian-security stretch/updates main' >> /etc/apt/sources.list
+RUN echo 'deb-src http://archive.debian.org/debian stretch-proposed-updates main' >> /etc/apt/sources.list
 
 RUN dpkg --add-architecture i386
 

--- a/environments/linux-amd64-wine_freebsdcross
+++ b/environments/linux-amd64-wine_freebsdcross
@@ -1,8 +1,12 @@
 FROM amd64/debian:stretch
 
-RUN echo 'deb-src http://deb.debian.org/debian stretch main' >> /etc/apt/sources.list
-RUN echo 'deb-src http://security.debian.org/debian-security stretch/updates main' >> /etc/apt/sources.list
-RUN echo 'deb-src http://deb.debian.org/debian stretch-updates main' >> /etc/apt/sources.list
+RUN echo 'deb http://archive.debian.org/debian stretch main' > /etc/apt/sources.list
+RUN echo 'deb http://archive.debian.org/debian-security stretch/updates main' >> /etc/apt/sources.list
+RUN echo 'deb http://archive.debian.org/debian stretch-proposed-updates main' >> /etc/apt/sources.list
+
+RUN echo 'deb-src http://archive.debian.org/debian stretch main' >> /etc/apt/sources.list
+RUN echo 'deb-src http://archive.debian.org/debian-security stretch/updates main' >> /etc/apt/sources.list
+RUN echo 'deb-src http://archive.debian.org/debian stretch-proposed-updates main' >> /etc/apt/sources.list
 
 RUN dpkg --add-architecture i386
 


### PR DESCRIPTION
Debian 9/stretch was moved to archive.debian.org

https://lists.debian.org/debian-devel-announce/2023/03/msg00006.html